### PR TITLE
Alert user when you cannot connect on any port

### DIFF
--- a/onionscan.go
+++ b/onionscan.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"github.com/s-rah/onionscan/config"
 	"github.com/s-rah/onionscan/protocol"
 	"github.com/s-rah/onionscan/report"
@@ -52,6 +54,11 @@ func (os *OnionScan) Scan(hiddenService string) (*report.OnionScanReport, error)
 	//SMTP
 	smps := new(protocol.SMTPProtocolScanner)
 	smps.ScanProtocol(hiddenService, os.Config, report)
+
+	if !report.WebDetected && !report.SSHDetected && !report.RicochetDetected && !report.BitcoinDetected && !report.IRCDetected && !report.FTPDetected && !report.SMTPDetected {
+		fmt.Printf("Unable to connect to this Tor Hidden Service on any known protocol.\n")
+		return nil, errors.New("Unable to connect to this Tor Hidden Service on any known protocol.")
+	}
 
 	return report, nil
 }

--- a/protocol/bitcoin_scanner.go
+++ b/protocol/bitcoin_scanner.go
@@ -16,6 +16,7 @@ func (rps *BitcoinProtocolScanner) ScanProtocol(hiddenService string, onionscanC
 	_, err := socks.DialSocksProxy(socks.SOCKS5, onionscanConfig.TorProxyAddress)("", hiddenService+":8333")
 	if err != nil {
 		log.Printf("Failed to connect to service on port 8333\n")
+		report.BitcoinDetected = false
 	} else {
 		log.Printf("Detected possible Bitcoin instance\n")
 		// TODO: Actual Analysis

--- a/protocol/ftp_scanner.go
+++ b/protocol/ftp_scanner.go
@@ -16,6 +16,7 @@ func (sps *FTPProtocolScanner) ScanProtocol(hiddenService string, onionscanConfi
 	_, err := socks.DialSocksProxy(socks.SOCKS5, onionscanConfig.TorProxyAddress)("", hiddenService+":21")
 	if err != nil {
 		log.Printf("Failed to connect to service on port 21\n")
+		report.FTPDetected = false
 	} else {
 		// TODO FTP Checking
 		report.FTPDetected = true

--- a/protocol/http_scanner.go
+++ b/protocol/http_scanner.go
@@ -31,6 +31,8 @@ func (hps *HTTPProtocolScanner) ScanProtocol(hiddenService string, onionscanConf
 	_, err := socks.DialSocksProxy(socks.SOCKS5, onionscanConfig.TorProxyAddress)("", hiddenService+":80")
 	if err != nil {
 		log.Printf("Failed to connect to service on port 80\n")
+		report.WebDetected = false
+		return
 	} else {
 		log.Printf("Found potential service on http(80)\n")
 		report.WebDetected = true

--- a/protocol/irc_scanner.go
+++ b/protocol/irc_scanner.go
@@ -16,6 +16,7 @@ func (rps *IRCProtocolScanner) ScanProtocol(hiddenService string, onionscanConfi
 	_, err := socks.DialSocksProxy(socks.SOCKS5, onionscanConfig.TorProxyAddress)("", hiddenService+":6667")
 	if err != nil {
 		log.Printf("Failed to connect to service on port 6667\n")
+		report.IRCDetected = false
 	} else {
 		log.Printf("Detected possible IRC instance\n")
 		// TODO: Actual Analysis

--- a/protocol/ricochet_scanner.go
+++ b/protocol/ricochet_scanner.go
@@ -16,6 +16,7 @@ func (rps *RicochetProtocolScanner) ScanProtocol(hiddenService string, onionscan
 	_, err := socks.DialSocksProxy(socks.SOCKS5, onionscanConfig.TorProxyAddress)("", hiddenService+":9878")
 	if err != nil {
 		log.Printf("Failed to connect to service on port 9878\n")
+		report.RicochetDetected = false
 	} else {
 		log.Printf("Detected possible ricochet instance\n")
 		// TODO: Actual Analysis

--- a/protocol/smtp_scanner.go
+++ b/protocol/smtp_scanner.go
@@ -16,6 +16,7 @@ func (sps *SMTPProtocolScanner) ScanProtocol(hiddenService string, onionscanConf
 	_, err := socks.DialSocksProxy(socks.SOCKS5, onionscanConfig.TorProxyAddress)("", hiddenService+":25")
 	if err != nil {
 		log.Printf("Failed to connect to service on port 25\n")
+		report.SMTPDetected = false
 	} else {
 		// TODO SMTP Checking
 		report.SMTPDetected = true

--- a/protocol/ssh_scanner.go
+++ b/protocol/ssh_scanner.go
@@ -21,6 +21,7 @@ func (sps *SSHProtocolScanner) ScanProtocol(hiddenService string, onionscanConfi
 	conn, err := socks.DialSocksProxy(socks.SOCKS5, onionscanConfig.TorProxyAddress)("", hiddenService+":22")
 	if err != nil {
 		log.Printf("Failed to connect to service on port 22\n")
+		report.SSHDetected = false
 	} else {
 		// TODO SSH Checking
 		report.SSHDetected = true


### PR DESCRIPTION
Failing to connect to a server on any port should raise an error.

I was running onionscan on my machine and every address returned:

```
--------------- OnionScan Report ---------------
High Risk Issues: 0
Medium Risk Issues: 0
Low Risk Issues: 0
Informational Issues: 0
```

I have an issue connecting to Tor from my location (Thailand)  (Edit: I now think that I set up the proxy wrong... issue still stands). Only when I ran with ```--verbose``` did I realize that onionscan wasn't connecting to the hidden service at all! Even then it reports 0 issues. This would make that information apparent and raise an error instead of returning a report.