### PR TITLE
Find images and links by parsing HTML

### DIFF
--- a/onionscan.go
+++ b/onionscan.go
@@ -6,6 +6,7 @@ import (
 	"github.com/s-rah/onionscan/config"
 	"github.com/s-rah/onionscan/protocol"
 	"github.com/s-rah/onionscan/report"
+	"github.com/s-rah/onionscan/utils"
 	"strings"
 )
 
@@ -16,10 +17,7 @@ type OnionScan struct {
 func (os *OnionScan) Scan(hiddenService string) (*report.OnionScanReport, error) {
 
 	// Remove Extra Prefix
-	// TODO: Add support for HTTPS?
-	if strings.HasPrefix(hiddenService, "http://") {
-		hiddenService = hiddenService[7:]
-	}
+	hiddenService = utils.WithoutProtocol(hiddenService)
 
 	if strings.HasSuffix(hiddenService, "/") {
 		hiddenService = hiddenService[0 : len(hiddenService)-1]

--- a/protocol/http_scanner.go
+++ b/protocol/http_scanner.go
@@ -76,9 +76,12 @@ func (hps *HTTPProtocolScanner) ScanProtocol(hiddenService string, onionscanConf
 }
 
 func (hps *HTTPProtocolScanner) ScanPage(hiddenService string, page string, report *report.OnionScanReport, f func(scans.Scanner, string, int, string, *report.OnionScanReport)) {
-	response, err := hps.Client.Get("http://" + hiddenService + page)
+	if !strings.Contains(page, utils.WithoutSubdomains(hiddenService)) {
+		page = hiddenService + page
+	}
+	response, err := hps.Client.Get("http://" + page)
 	if err != nil {
-		log.Printf("Error connecting to %s%s %s\n", hiddenService, page, err)
+		log.Printf("Error connecting to http://%s %s\n", page, err)
 		return
 	}
 	defer response.Body.Close()

--- a/report/onionscanreport.go
+++ b/report/onionscanreport.go
@@ -33,6 +33,7 @@ type OnionScanReport struct {
 	RelatedOnionServices      []string    `json:"relatedOnionServices"`
 	RelatedClearnetDomains    []string    `json:"relatedOnionDomains"`
 	LinkedSites               []string    `json:"linkedSites"`
+	InternalPages             []string    `json:"InternalPages"`
 	IP                        []string    `json:"ipAddresses"`
 	OpenDirectories           []string    `json:"openDirectories"`
 	ExifImages                []ExifImage `json:"exifImages"`
@@ -84,6 +85,11 @@ func (osr *OnionScanReport) AddIPAddress(ip string) {
 func (osr *OnionScanReport) AddLinkedSite(site string) {
 	osr.LinkedSites = append(osr.LinkedSites, site)
 	utils.RemoveDuplicates(&osr.LinkedSites)
+}
+
+func (osr *OnionScanReport) AddInternalPage(site string) {
+	osr.InternalPages = append(osr.InternalPages, site)
+	utils.RemoveDuplicates(&osr.InternalPages)
 }
 
 func (osr *OnionScanReport) AddPGPKey(key string) {

--- a/utils/html_parsing.go
+++ b/utils/html_parsing.go
@@ -1,0 +1,12 @@
+package utils
+
+import "golang.org/x/net/html"
+
+func GetAttribute(tag html.Token, name string) string {
+	for _, a := range tag.Attr {
+		if a.Key == name {
+			return a.Val
+		}
+	}
+	return ""
+}

--- a/utils/url_parsing.go
+++ b/utils/url_parsing.go
@@ -1,0 +1,29 @@
+package utils
+
+import (
+	"github.com/mvdan/xurls"
+	"strings"
+)
+
+func ExtractDomains(content string) []string {
+	return xurls.Strict.FindAllString(content, -1)
+}
+
+func WithoutSubdomains(urlhost string) string {
+	urlParts := strings.Split(urlhost, ".")
+	if len(urlParts) < 2 {
+		return ""
+	} else {
+		return strings.Join(urlParts[len(urlParts)-2:], ".")
+	}
+}
+
+func WithoutProtocol(url string) string {
+	if strings.HasPrefix(url, "http://") {
+		return url[7:]
+	}
+	if strings.HasPrefix(url, "https://") {
+		return url[8:]
+	}
+	return url
+}

--- a/utils/useful_regexps.go
+++ b/utils/useful_regexps.go
@@ -1,7 +1,0 @@
-package utils
-
-import "github.com/mvdan/xurls"
-
-func ExtractDomains(content string) []string {
-	return xurls.Strict.FindAllString(content, -1)
-}


### PR DESCRIPTION
This is a large PR but I was trying to use it to scan ```facebookcorewwwi.onion```

Uses an HTML parser (golang.org/x/net/html) to go through all of the ```<a>``` and ```<img/>``` tags to extract links

Considers subdomains (www, m) to be part of the same onion site in reports, EXIF data checks, etc

Smaller changes:
- if user enters http:// or https:// in the command line, remove it and just look at the hostname (facebookcorewwwi.onion, www.facebookcorewwi.onion)
- if an img tag or link uses full instead of relative path (https://my.onion/link/to/image) then it can still be recognized as an internal link
- store InternalPages in the report, just like LinkedSites