### PR TITLE
Add mongodb check

### DIFF
--- a/onionscan.go
+++ b/onionscan.go
@@ -55,7 +55,7 @@ func (os *OnionScan) Scan(hiddenService string) (*report.OnionScanReport, error)
 	smps := new(protocol.SMTPProtocolScanner)
 	smps.ScanProtocol(hiddenService, os.Config, report)
 
-	if !report.WebDetected && !report.SSHDetected && !report.RicochetDetected && !report.BitcoinDetected && !report.IRCDetected && !report.FTPDetected && !report.SMTPDetected {
+	if !report.WebDetected && !report.SSHDetected && !report.RicochetDetected && !report.BitcoinDetected && !report.IRCDetected && !report.FTPDetected && !report.SMTPDetected && !report.MongoDBDetected {
 		fmt.Printf("Unable to connect to this Tor Hidden Service on any known protocol.\n")
 		return nil, errors.New("Unable to connect to this Tor Hidden Service on any known protocol.")
 	}

--- a/protocol/mongodb_scanner.go
+++ b/protocol/mongodb_scanner.go
@@ -1,0 +1,26 @@
+package protocol
+
+import (
+	"github.com/s-rah/onionscan/config"
+	"github.com/s-rah/onionscan/report"
+	"h12.me/socks"
+	"log"
+)
+
+type MongoDBProtocolScanner struct {
+}
+
+func (rps *MongoDBProtocolScanner) ScanProtocol(hiddenService string, onionscanConfig *config.OnionscanConfig, report *report.OnionScanReport) {
+	// MongoDB
+	log.Printf("Checking %s MongoDB(27017)\n", hiddenService)
+	_, err := socks.DialSocksProxy(socks.SOCKS5, onionscanConfig.TorProxyAddress)("", hiddenService+":27017")
+	if err != nil {
+		log.Printf("Failed to connect to service on port 27017\n")
+		report.MongoDBDetected = false
+	} else {
+		log.Printf("Detected possible MongoDB instance\n")
+		// TODO: Actual Analysis
+		report.MongoDBDetected = true
+	}
+
+}

--- a/report/onionscanreport.go
+++ b/report/onionscanreport.go
@@ -25,6 +25,7 @@ type OnionScanReport struct {
 	SMTPDetected     bool `json:"smtpDetected"`
 
 	BitcoinDetected bool `json:"bitcoinDetected"`
+	MongoDBDetected bool `json:"mongodbDetected"`
 
 	HiddenService             string      `json:"hiddenService"`
 	ServerPoweredBy           string      `json:"serverPoweredBy"`


### PR DESCRIPTION
Mongodb is often not password protected, leaving databases exposed. Additionally, mongodb can reveal identifying information about the host.