### PR TITLE
Scan CSS style tags and stylesheet links

### DIFF
--- a/scans/scanner.go
+++ b/scans/scanner.go
@@ -6,4 +6,5 @@ import (
 
 type Scanner interface {
 	ScanPage(string, string, *report.OnionScanReport, func(Scanner, string, int, string, *report.OnionScanReport))
+	ScrapePage(string, string) (error, []byte, int)
 }

--- a/utils/url_parsing.go
+++ b/utils/url_parsing.go
@@ -2,11 +2,23 @@ package utils
 
 import (
 	"github.com/mvdan/xurls"
+	"regexp"
 	"strings"
 )
 
 func ExtractDomains(content string) []string {
-	return xurls.Strict.FindAllString(content, -1)
+	domains := xurls.Strict.FindAllString(content, -1)
+	cssurlregex := regexp.MustCompile(`(?i)url\((.*?)\)`)
+	cssDomains := cssurlregex.FindAllString(content, -1)
+	for _, cssDomain := range cssDomains {
+		if strings.HasPrefix(strings.ToLower(cssDomain), "url(") {
+			cssDomain = cssDomain[4 : len(cssDomain)-1]
+		}
+		if !strings.HasSuffix(cssDomain, ":before") && !strings.HasSuffix(cssDomain, ":after") {
+			domains = append(domains, cssDomain)
+		}
+	}
+	return domains
 }
 
 func WithoutSubdomains(urlhost string) string {
@@ -24,6 +36,9 @@ func WithoutProtocol(url string) string {
 	}
 	if strings.HasPrefix(url, "https://") {
 		return url[8:]
+	}
+	if strings.HasPrefix(url, "//") {
+		return url[2:]
 	}
 	return url
 }


### PR DESCRIPTION
Trying to solve the issue which I mentioned in #39 - how to detect fonts and background-images included via CSS?

- ```<style>``` tags can be scanned if we check the page source - added CSS URL checking to ```utils.ExtractDomains```
- checking ```<link rel="stylesheet"/>``` tags can be done using the HTML parser and making available ```ScrapePage``` as a dumber version of the ```ScanPage``` method.
- also noticed that some URLs begin with // instead of http or https; now handling those