### PR TITLE
extract PGP identity and fingerprint (as supplied by x/crypto/openpgp)

### DIFF
--- a/report/onionscanreport.go
+++ b/report/onionscanreport.go
@@ -16,6 +16,12 @@ type ExifImage struct {
 	ExifTags []ExifTag `json:"exifTags"`
 }
 
+type PGPKey struct {
+	ArmoredKey	string	`json:"armoredKey"`
+	Identity	string	`json:"identity"`
+	FingerPrint	string	`json:"fingerprint"`
+}
+
 type OnionScanReport struct {
 	HiddenService string `json:"hiddenService"`
 
@@ -43,7 +49,7 @@ type OnionScanReport struct {
 	ExifImages                []ExifImage       `json:"exifImages"`
 	InterestingFiles          []string          `json:"interestingFiles"`
 	PageReferencedDirectories []string          `json:"pageReferencedDirectories"`
-	PGPKeys                   []string          `json:"pgpKeys"`
+	PGPKeys                   []PGPKey    `json:"pgpKeys"`
 	Hashes                    []string          `json:"hashes"`
 	Snapshot                  string            `json:"snapshot"`
 	PageTitle                 string            `json:"pageTitle"`
@@ -105,9 +111,9 @@ func (osr *OnionScanReport) AddInternalPage(site string) {
 	utils.RemoveDuplicates(&osr.InternalPages)
 }
 
-func (osr *OnionScanReport) AddPGPKey(key string) {
-	osr.PGPKeys = append(osr.PGPKeys, key)
-	utils.RemoveDuplicates(&osr.PGPKeys)
+func (osr *OnionScanReport) AddPGPKey(armoredKey, identity, fingerprint string) {
+	osr.PGPKeys = append(osr.PGPKeys, PGPKey{armoredKey, identity, fingerprint})
+	//TODO map of fingerprint:PGPKeys? and  utils.RemoveDuplicates(&osr.PGPKeys)
 }
 
 func (osr *OnionScanReport) AddResponseHeader(name string, value string) {

--- a/scans/pgp_content_scan.go
+++ b/scans/pgp_content_scan.go
@@ -2,18 +2,39 @@ package scans
 
 import (
 	"github.com/s-rah/onionscan/report"
+	"golang.org/x/crypto/openpgp"
 	"log"
 	"regexp"
+	"strings"
+	"fmt"
 )
 
 type PGPContentScan struct {
 }
 
 func (cs *PGPContentScan) ScanContent(content string, report *report.OnionScanReport) {
-	log.Printf("\tScanning for PGP Key\n")
+	log.Printf("Scanning for PGP Key\n")
 	pgpRegexp := regexp.MustCompile("-----BEGIN PGP PUBLIC KEY BLOCK-----((?s).*)-----END PGP PUBLIC KEY BLOCK-----")
 	foundPGP := pgpRegexp.FindAllString(content, -1)
-	for _, key := range foundPGP {
-		report.AddPGPKey(key)
+	for _, keyString := range foundPGP {
+		keys, err := openpgp.ReadArmoredKeyRing(strings.NewReader(keyString));
+		if err != nil {
+			log.Printf("ERROR: %s\n", err)
+			continue
+		}
+		if len(keys) < 1 || len(keys[0].Subkeys) < 1 || len(keys[0].Identities) < 1{
+			log.Printf("ERROR: failed to accept key\n")
+			continue
+		}
+
+		var identity string
+		for identity, _ = range keys[0].Identities {
+			break
+		}
+		var fingerprint string
+		fingerprint = fmt.Sprintf("%X", keys[0].Subkeys[0].PublicKey.Fingerprint)
+		log.Printf("\tFound PGP Key fingerprint: %s belonging to %s", fingerprint, identity)
+
+		report.AddPGPKey(keyString, identity, fingerprint)
 	}
 }


### PR DESCRIPTION
Adds support for using opengpg to extract identity and fingerprint (I think the fingerprinting can be expanded, openpgp wants to only give a sha1 but most of my tools still use  md5 so they don't match).
Also if we want a info or warning that can be added now or in a later patch