### PR TITLE
Update import path for `socks` package

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ deanonymize.
 
 ## Go Dependencies
 
-* h12.me/socks - For the Tor SOCKS Proxy connection.
+* github.com/h12w/socks - For the Tor SOCKS Proxy connection.
 * github.com/xiam/exif - For EXIF data extraction.
 * github.com/mvdan/xurls - For some URL parsing.
 

--- a/protocol/http_scanner.go
+++ b/protocol/http_scanner.go
@@ -5,7 +5,7 @@ import (
 	"github.com/s-rah/onionscan/report"
 	"github.com/s-rah/onionscan/scans"
 	"github.com/s-rah/onionscan/utils"
-	"h12.me/socks"
+	"github.com/h12w/socks"
 	"io/ioutil"
 	"log"
 	"net/http"

--- a/utils/networking.go
+++ b/utils/networking.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	"h12.me/socks"
+	"github.com/h12w/socks"
 	"net"
 	"strconv"
 	"time"


### PR DESCRIPTION
The URL `h12.me/socks` is under CloudFlare thus it's unavailable for Tor users. Actually it redirects to `github.com/h12w/socks` after CFC. 