### PR TITLE
Switch to golang.org/x/net/proxy from h12.me/socks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ deanonymize.
 
 ## Go Dependencies
 
-* h12.me/socks - For the Tor SOCKS Proxy connection.
+* golang.org/x/net/proxy - For the Tor SOCKS Proxy connection.
 * github.com/xiam/exif - For EXIF data extraction.
 * github.com/mvdan/xurls - For some URL parsing.
 

--- a/protocol/http_scanner.go
+++ b/protocol/http_scanner.go
@@ -7,7 +7,7 @@ import (
 	"github.com/s-rah/onionscan/report"
 	"github.com/s-rah/onionscan/scans"
 	"github.com/s-rah/onionscan/utils"
-	"h12.me/socks"
+	"golang.org/x/net/proxy"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -40,9 +40,12 @@ func (hps *HTTPProtocolScanner) ScanProtocol(hiddenService string, osc *config.O
 		osc.LogInfo("Found potential service on http(80)\n")
 		report.WebDetected = true
 		conn.Close()
-		dialSocksProxy := socks.DialSocksProxy(socks.SOCKS5, osc.TorProxyAddress)
+		torDialer, err := proxy.SOCKS5("tcp", osc.TorProxyAddress, nil, proxy.Direct)
+		if err != nil {
+			osc.LogError(err)
+		}
 		transportConfig := &http.Transport{
-			Dial:            dialSocksProxy,
+			Dial:            torDialer.Dial,
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}
 		hps.Client = &http.Client{

--- a/utils/networking.go
+++ b/utils/networking.go
@@ -1,15 +1,19 @@
 package utils
 
 import (
-	"h12.me/socks"
+	"golang.org/x/net/proxy"
 	"net"
 	"strconv"
 	"time"
 )
 
-func GetNetworkConnection(onionService string, port int, proxy string, timeout time.Duration) (net.Conn, error) {
+func GetNetworkConnection(onionService string, port int, proxyAddress string, timeout time.Duration) (net.Conn, error) {
 	portNumber := strconv.Itoa(port)
-	conn, err := socks.DialSocksProxy(socks.SOCKS5, proxy)("", onionService+":"+portNumber)
+	torDialer, err := proxy.SOCKS5("tcp", proxyAddress, nil, proxy.Direct)
+	if err != nil {
+		return nil, err
+	}
+	conn, err := torDialer.Dial("tcp", onionService+":"+portNumber)
 	if err == nil {
 		conn.SetDeadline(time.Now().Add(timeout))
 	}

--- a/utils/networking.go
+++ b/utils/networking.go
@@ -14,8 +14,9 @@ func GetNetworkConnection(onionService string, port int, proxyAddress string, ti
 		return nil, err
 	}
 	conn, err := torDialer.Dial("tcp", onionService+":"+portNumber)
-	if err == nil {
-		conn.SetDeadline(time.Now().Add(timeout))
+	if err != nil {
+		return nil, err
 	}
+	conn.SetDeadline(time.Now().Add(timeout))
 	return conn, err
 }


### PR DESCRIPTION
Made it mostly because of CFC(#50) and no evident advantage of `h12.me/socks` over `golang.org` proxy implementation.