### PR TITLE
Make which scans to run configurable

### DIFF
--- a/config/onionscan_config.go
+++ b/config/onionscan_config.go
@@ -14,9 +14,10 @@ type OnionScanConfig struct {
 	Verbose         bool
 	Database        *crawldb.CrawlDB
 	RescanDuration  time.Duration
+	Scans           []string
 }
 
-func Configure(torProxyAddress string, directoryDepth int, fingerprint bool, timeout int, database string, verbose bool) *OnionScanConfig {
+func Configure(torProxyAddress string, directoryDepth int, fingerprint bool, timeout int, database string, scans []string, verbose bool) *OnionScanConfig {
 	osc := new(OnionScanConfig)
 	osc.TorProxyAddress = torProxyAddress
 	osc.Depth = directoryDepth
@@ -26,6 +27,7 @@ func Configure(torProxyAddress string, directoryDepth int, fingerprint bool, tim
 	osc.Database = new(crawldb.CrawlDB)
 	osc.Database.NewDB(database)
 	osc.RescanDuration = time.Hour * -100
+	osc.Scans = scans
 	return osc
 }
 

--- a/main.go
+++ b/main.go
@@ -33,6 +33,8 @@ func main() {
 	timeout := flag.Int("timeout", 120, "read timeout for connecting to onion services")
 	batch := flag.Int("batch", 10, "number of onions to scan concurrently")
 	dbdir := flag.String("dbdir", "./onionscandb", "The directory where the crawl database will be stored")
+	scans := flag.String("scans", "", "a comma-separated list of scans to run e.g. web,tls,... (default: run all)")
+
 	flag.Parse()
 
 	if len(flag.Args()) != 1 && *list == "" {
@@ -62,7 +64,15 @@ func main() {
 	log.Printf("This might take a few minutes..\n\n")
 
 	onionScan := new(onionscan.OnionScan)
-	onionScan.Config = config.Configure(*torProxyAddress, *directoryDepth, *fingerprint, *timeout, *dbdir, *verbose)
+
+	var scans_list []string
+	if *scans != "" {
+		scans_list = strings.Split(*scans, ",")
+	} else {
+		scans_list = onionScan.GetAllActions()
+	}
+
+	onionScan.Config = config.Configure(*torProxyAddress, *directoryDepth, *fingerprint, *timeout, *dbdir, scans_list, *verbose)
 
 	reports := make(chan *report.OnionScanReport)
 

--- a/report/onionscanreport.go
+++ b/report/onionscanreport.go
@@ -14,9 +14,10 @@ type PGPKey struct {
 }
 
 type OnionScanReport struct {
-	HiddenService string    `json:"hiddenService"`
-	DateScanned   time.Time `json:"dateScanned"`
-	Online        bool      `json:"online"`
+	HiddenService  string    `json:"hiddenService"`
+	DateScanned    time.Time `json:"dateScanned"`
+	Online         bool      `json:"online"`
+	PerformedScans []string  `json:"performedScans"`
 
 	// Summary
 	WebDetected      bool `json:"webDetected"`
@@ -42,9 +43,9 @@ type OnionScanReport struct {
 	Certificates []x509.Certificate `json:"certificates"`
 
 	//Bitcoin
-	BitcoinAddresses []string `json:"bitcoinAddresses"`
-	BitcoinUserAgent string `json:"bitcoinUserAgent"`
-	BitcoinProtocolVersion int `json:"bitcoinPrototocolVersion"`
+	BitcoinAddresses       []string `json:"bitcoinAddresses"`
+	BitcoinUserAgent       string   `json:"bitcoinUserAgent"`
+	BitcoinProtocolVersion int      `json:"bitcoinPrototocolVersion"`
 
 	// SSH
 	SSHKey    string `json:"sshKey"`
@@ -77,6 +78,7 @@ func NewOnionScanReport(hiddenService string) *OnionScanReport {
 	report.HiddenService = hiddenService
 	report.DateScanned = time.Now()
 	report.Crawls = make(map[string]int)
+	report.PerformedScans = []string{}
 	return report
 }
 


### PR DESCRIPTION
Not sure if this is the right way to go at it, but I think this is useful during development, when testing a single scan or when one wants to run a couple of them quickly.

It adds a command-line option `-scans` to configure what scans to run:
```
  -scans string
        a comma-separated list of scans to run e.g. web,tls,... (default: run all)
```

Also report the scans that were performed in the report as `PerformedScans`.

Wasn't sure what to do with `Report.NextAction`, as `PerformedScans` essentially gives the same and more information, but I kept it for backwards compatibility.