### PR TITLE
Parametrize bitcoin scan to be able to scan for other coins

### DIFF
--- a/onionscan/onionscan.go
+++ b/onionscan/onionscan.go
@@ -27,6 +27,9 @@ func (os *OnionScan) GetAllActions() []string {
 		"vnc",
 		"xmpp",
 		"bitcoin",
+		"bitcoin_test",
+		"litecoin",
+		"dogecoin",
 	}
 }
 
@@ -62,8 +65,8 @@ func (os *OnionScan) PerformNextAction(report *report.OnionScanReport, nextActio
 	case "xmpp":
 		xmppps := new(protocol.XMPPProtocolScanner)
 		xmppps.ScanProtocol(report.HiddenService, os.Config, report)
-	case "bitcoin":
-		bps := new(protocol.BitcoinProtocolScanner)
+	case "bitcoin", "bitcoin_test", "litecoin", "litecoin_test", "dogecoin", "dogecoin_test":
+		bps := protocol.NewBitcoinProtocolScanner(nextAction)
 		bps.ScanProtocol(report.HiddenService, os.Config, report)
 	case "none":
 		return nil

--- a/report/onionscanreport.go
+++ b/report/onionscanreport.go
@@ -13,6 +13,13 @@ type PGPKey struct {
 	FingerPrint string `json:"fingerprint"`
 }
 
+type BitcoinService struct {
+	Detected        bool     `json:"detected"`
+	UserAgent       string   `json:"userAgent"`
+	ProtocolVersion int      `json:"prototocolVersion"`
+	OnionPeers      []string `json:"onionPeers"`
+}
+
 type OnionScanReport struct {
 	HiddenService  string    `json:"hiddenService"`
 	DateScanned    time.Time `json:"dateScanned"`
@@ -42,11 +49,9 @@ type OnionScanReport struct {
 	// TLS
 	Certificates []x509.Certificate `json:"certificates"`
 
-	//Bitcoin
-	BitcoinAddresses       []string `json:"bitcoinAddresses"`
-	BitcoinUserAgent       string   `json:"bitcoinUserAgent"`
-	BitcoinProtocolVersion int      `json:"bitcoinPrototocolVersion"`
-	BitcoinOnionPeers      []string `json:"bitcoinOnionPeers"`
+	// Bitcoin
+	BitcoinAddresses []string                   `json:"bitcoinAddresses"`
+	BitcoinServices  map[string]*BitcoinService `json:"bitcoinServices"`
 
 	// SSH
 	SSHKey    string `json:"sshKey"`
@@ -80,12 +85,19 @@ func NewOnionScanReport(hiddenService string) *OnionScanReport {
 	report.DateScanned = time.Now()
 	report.Crawls = make(map[string]int)
 	report.PerformedScans = []string{}
+	report.BitcoinServices = make(map[string]*BitcoinService)
 	return report
 }
 
 func (osr *OnionScanReport) AddPGPKey(armoredKey, identity, fingerprint string) {
 	osr.PGPKeys = append(osr.PGPKeys, PGPKey{armoredKey, identity, fingerprint})
 	//TODO map of fingerprint:PGPKeys? and  utils.RemoveDuplicates(&osr.PGPKeys)
+}
+
+func (osr *OnionScanReport) AddBitcoinService(name string) *BitcoinService {
+	var s = new(BitcoinService)
+	osr.BitcoinServices[name] = s
+	return s
 }
 
 func (osr *OnionScanReport) Serialize() (string, error) {


### PR DESCRIPTION
This pull request parametrizes the bitcoin scanner and so adds support for scanning other bitcoin-derived protocols.

### Report changes

To be able to store the dynamic information I created a per-service report map `BitcoinService`. This contains the bitcoin fields that used to be on the report directly, but per scan.

For example, after scanning a bitcoin testnet node:
```bash
$ ./onionscan -jsonReport -scans bitcoin_test -verbose aaiilnwzuqpx5o6j.onion
```
```json
        "bitcoinServices": {
            "bitcoin_test": {
                "detected": true,
                "userAgent": "/Satoshi:0.13.0(aaiilnwzuqpx5o6j)/",
                "prototocolVersion": 70014,
                "onionPeers": [
                    "aaiilnwzuqpx5o6j.onion:18333",
                    "nec4kn4ghql7p7an.onion:18333",
                    "gl3wjwdsxa62uxln.onion:18333",
                    "6vu4juq6hhomxrel.onion:18333",
                    "cjz4w57h2zasljw3.onion:18333",
                    "bbgw7gpjpko5yvuh.onion:18333",
                    "attdhwktlpnfaluw.onion:18333",
                    "l24shdlfjbmr3txf.onion:18333",
                    "nkf5e6b7pl4jfd4a.onion:18333"
                ]
            }
        },
```
Please let me know if this is the right approach or if you'd prefer something else.

### Coins

To get started I added dogecoin and litecoin, as well as the respective testnets of bitcoin, dogecoin and litecoin.

There are tons of bitcoin testnet nodes to be found on Tor. I haven't actually managed to find any onion nodes for litecoin and dogecoin though. Maybe you have more luck :)

I did not enable the scans for litecoin and dogecoin testnets by default. As their mainnet nodes are already so hard to find on tor, looking for these is probably a waste of time.

### Adding new coins

There are literally hundreds of different altcoins derived from the bitcoin source, although most have no user base to speak of.

Assuming a coin's protocol (the subset for version negotiation and address exchange) is close enough to that of bitcoin for this to work, adding support for a new coin is trivial:

- Find the port and the four message start bytes for the coin. Usually these are in `src/chainparams.h`
- Add them to `NewBitcoinProtocolScanner` in a new case option
- Add the scan to `onionscan.PerformNextAction`
