### PR TITLE
Switch to native-go EXIF library

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,11 @@ deanonymize.
 ## Go Dependencies
 
 * golang.org/x/net/proxy - For the Tor SOCKS Proxy connection.
-* github.com/xiam/exif - For EXIF data extraction.
+* github.com/rwcarlsen/goexif - For EXIF data extraction.
 * github.com/mvdan/xurls - For some URL parsing.
 * github.com/HouzuoGuo/tiedot/db - For crawl database.
 
-## OS Package Dependencies
-
-* libexif-dev on Debian based OS
-* libexif-devel on Fedora
-
 ## Installing
-
-### Install OS dependencies
-
-* On Debian based operating systems: `sudo apt-get install libexif-dev`
-* On Fedora based operating systems: `sudo dnf install libexif-devel`
 
 ### Grab with go get
 
@@ -52,6 +42,10 @@ There is also a JSON output, if you want to integrate with something else:
 If you would like to use a proxy server listening on something other that `127.0.0.1:9050`, then you can use the --torProxyAddress flag:
 
 `./bin/onionscan --torProxyAddress=127.0.0.1:9150 blahblahblah.onion`
+
+To only scan for the web service and skip the other scans
+
+`./bin/onionscan --scans web --torProxyAddress=127.0.0.1:9150 blahblahblah.onion`
 
 ## Apache mod_status Protection
 

--- a/deanonymization/check_exif.go
+++ b/deanonymization/check_exif.go
@@ -2,45 +2,38 @@ package deanonymization
 
 import (
 	"bytes"
+	"github.com/rwcarlsen/goexif/exif"
+	"github.com/rwcarlsen/goexif/tiff"
 	"github.com/s-rah/onionscan/config"
 	"github.com/s-rah/onionscan/report"
-	"github.com/xiam/exif"
-	"io"
 	"net/url"
 	"strings"
 )
 
-func CheckExif(osreport *report.OnionScanReport, anonreport *report.AnonymityReport, osc *config.OnionScanConfig) {
+type ExifWalker struct {
+	anonreport *report.AnonymityReport
+}
 
+func (w *ExifWalker) Walk(name exif.FieldName, val *tiff.Tag) error {
+	w.anonreport.AddExifTag(string(name), val.String())
+	return nil
+}
+
+func CheckExif(osreport *report.OnionScanReport, anonreport *report.AnonymityReport, osc *config.OnionScanConfig) {
 	for _, id := range osreport.Crawls {
 		crawlRecord, _ := osc.Database.GetCrawlRecord(id)
 
 		if crawlRecord.Page.Status == 200 && strings.Contains(crawlRecord.Page.Headers.Get("Content-Type"), "image/jpeg") {
-			reader := exif.New()
-			_, err := io.Copy(reader, bytes.NewReader(crawlRecord.Page.Raw))
-
-			// exif.FoundExifInData is a signal that the EXIF parser has all it needs,
-			// it doesn't need to be given the whole image.
-			if err != nil && err != exif.ErrFoundExifInData {
-				// We don't care if we fail
-				return
-			}
-
-			err = reader.Parse()
+			exifdata, err := exif.Decode(bytes.NewReader(crawlRecord.Page.Raw))
 
 			if err != nil {
-				// We don't care if we fail
-				return
+				// We don't care if we fail - try next image
+				continue
 			}
 
-			if len(reader.Tags) > 0 {
-				uri, _ := url.Parse(crawlRecord.URL)
-				anonreport.AddExifImage(uri.Path)
-
-				for name, val := range reader.Tags {
-					anonreport.AddExifTag(name, val)
-				}
-			}
+			uri, _ := url.Parse(crawlRecord.URL)
+			anonreport.AddExifImage(uri.Path)
+			exifdata.Walk(&ExifWalker{anonreport})
 		}
 	}
 }


### PR DESCRIPTION
Use [goexif](https://github.com/rwcarlsen/goexif/) instead of libexif for EXIF parsing.

Builds on #67. Implements #63.

This is a bit of a proof of concept. The goexif page mentions that the software is still in alpha. As it looks like the upstream maintainer isn't very active maintaining it there are [a lot of forks](https://github.com/rwcarlsen/goexif/network) of this library that add extra functionality or maybe fix bugs. I haven't looked deeply into this.

The change affects the output. For example:
- [4hwyik7xxwb6pbvb_1.txt](https://github.com/s-rah/onionscan/files/504962/4hwyik7xxwb6pbvb_1.txt)  Example with libexif
- [4hwyik7xxwb6pbvb_2.txt](https://github.com/s-rah/onionscan/files/504963/4hwyik7xxwb6pbvb_2.txt) Example with goexif

There is the same information, but the conversion to strings happens differently. E.g. `F-Number` in the one is `FNumber` in the other. This may break current postprocessing. It would be possible to map them to the same names and value representation in an additional processing step, ofcourse.
