### PR TITLE
http protocol: close probing connection immediately

### DIFF
--- a/protocol/http_scanner.go
+++ b/protocol/http_scanner.go
@@ -19,12 +19,12 @@ func (hps *HTTPProtocolScanner) ScanProtocol(hiddenService string, osc *config.O
 	// HTTP
 	osc.LogInfo(fmt.Sprintf("Checking %s http(80)\n", hiddenService))
 	conn, err := utils.GetNetworkConnection(hiddenService, 80, osc.TorProxyAddress, osc.Timeout)
+	if conn != nil {
+		conn.Close()
+	}
 	if err != nil {
 		osc.LogInfo("Failed to connect to service on port 80\n")
 		report.WebDetected = false
-		if conn != nil {
-			conn.Close()
-		}
 	} else {
 		osc.LogInfo("Found potential service on http(80)\n")
 		report.WebDetected = true


### PR DESCRIPTION
I was noticing strange behavior where an extra HTTP connection would be open for the whole time the spider ran, which did not get any request.

This turned out to be the initial probing connection to see if port 80 is open. It is subsequentially never used until the handle goes out of scope.

In thie patch I changed it to close the connection immediately. This saves some resources on the server side (as well as makes single-threaded test servers such as Python's SimpleServer not hang during spidering).