### PR TITLE
travis: add gofmt checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,8 @@ notifications:
    email:
      recipients:
        - team@onionscan.org
+
+script:
+    - go test -v ./...
+    - GOFMT=$(gofmt -d .) && echo "$GOFMT"
+    - test -z "$GOFMT"

--- a/spider/onionspider.go
+++ b/spider/onionspider.go
@@ -20,11 +20,11 @@ type OnionSpider struct {
 func (os *OnionSpider) Crawl(hiddenservice string, osc *config.OnionScanConfig, report *report.OnionScanReport) {
 
 	torDialer, err := proxy.SOCKS5("tcp", osc.TorProxyAddress, nil, proxy.Direct)
-	
+
 	if err != nil {
-	        osc.LogError(err)
+		osc.LogError(err)
 	}
-	
+
 	transportConfig := &http.Transport{
 		Dial:            torDialer.Dial,
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},


### PR DESCRIPTION
Print a diff and fail the check if any code is not gofmt-ed.

`go test -v ./...` is the [default test script](https://docs.travis-ci.com/user/languages/go#Default-Test-Script), so that goes first.

(Edit: this fails on the current code, as there needs to be a diff on `onionspider`, I'll add that once I get the output right)
(Edit.2: added the commit to fix the formatting. [here](https://travis-ci.org/s-rah/onionscan/jobs/164553666)'s still an example of Travis failing without it)