### PR TITLE
Check private_key and raise an alarm if it is a hidden service key

### DIFF
--- a/deanonymization/private_key.go
+++ b/deanonymization/private_key.go
@@ -1,0 +1,43 @@
+package deanonymization
+
+import (
+	"net/url"
+
+	"encoding/base64"
+	"github.com/s-rah/onionscan/config"
+	"github.com/s-rah/onionscan/report"
+	"strings"
+)
+
+func ProcessKey(osreport *report.OnionScanReport, report *report.AnonymityReport, osc *config.OnionScanConfig, key string) {
+	_, err := base64.StdEncoding.DecodeString(key)
+	if err == nil { // Parses as base64 - could further check data as DER key, but this seems enough
+		report.PrivateKeyDetected = true
+	}
+}
+
+func PrivateKey(osreport *report.OnionScanReport, report *report.AnonymityReport, osc *config.OnionScanConfig) {
+	for _, id := range osreport.Crawls {
+		crawlRecord, _ := osc.Database.GetCrawlRecord(id)
+
+		uri, _ := url.Parse(crawlRecord.URL)
+		if crawlRecord.Page.Status == 200 && strings.HasSuffix(uri.Path, "/private_key") {
+			contents := crawlRecord.Page.Snapshot
+
+			key := ""
+			inKey := false
+			for _, line := range strings.Split(contents, "\n") {
+				line := strings.TrimSpace(line)
+				if line == "-----BEGIN RSA PRIVATE KEY-----" {
+					inKey = true
+					key = ""
+				} else if line == "-----END RSA PRIVATE KEY-----" {
+					ProcessKey(osreport, report, osc, key)
+					inKey = false
+				} else if inKey {
+					key += line
+				}
+			}
+		}
+	}
+}

--- a/deanonymization/process_report.go
+++ b/deanonymization/process_report.go
@@ -13,6 +13,7 @@ func ProcessReport(osreport *report.OnionScanReport, osc *config.OnionScanConfig
 	PGPContentScan(osreport, anonreport, osc)
 	MailtoScan(osreport, anonreport, osc)
 	CheckExif(osreport, anonreport, osc)
+	PrivateKey(osreport, anonreport, osc)
 	ExtractGoogleAnalyticsID(osreport, anonreport, osc)
 	ExtractGooglePublisherID(osreport, anonreport, osc)
 	ExtractBitcoinAddress(osreport, anonreport, osc)

--- a/report/report_generator.go
+++ b/report/report_generator.go
@@ -143,6 +143,13 @@ func GenerateSimpleReport(reportFile string, report *AnonymityReport) {
 		buffer.WriteString("\n")
 	}
 
+	if report.PrivateKeyDetected {
+		buffer.WriteString("\033[091mCritical Risk:\033[0m Hidden service private key is accessible!\n")
+		buffer.WriteString("\t Why this is bad: This can be used to impersonate the service at any point in the future.\n")
+		buffer.WriteString("\t To fix, generate a new hidden service and make sure the private_key file is not reachable from\n")
+		buffer.WriteString("\t the web root\n")
+	}
+
 	if len(reportFile) > 0 {
 		f, err := os.Create(reportFile)
 


### PR DESCRIPTION
Checks retrieved files whose names end in `/private_key` and check whether they are hidden service private keys (well, base64 encoded RSA keys).

Example:
```
./onionscan -scans web -verbose 4hwyik7xxwb6pbvb.onion
```
```
...
Critical Risk: Hidden service private key is accessible!
         Why this is bad: This can be used to impersonate the service at any point in the future.
         To fix, generate a new hidden service and make sure the private_key file is not reachable from
         the web root
...
```

Implements #52.