### PR TITLE
Remove unused field OnionScanReport.BitcoinAddresses

### DIFF
--- a/report/onionscanreport.go
+++ b/report/onionscanreport.go
@@ -50,8 +50,7 @@ type OnionScanReport struct {
 	Certificates []x509.Certificate `json:"certificates"`
 
 	// Bitcoin
-	BitcoinAddresses []string                   `json:"bitcoinAddresses"`
-	BitcoinServices  map[string]*BitcoinService `json:"bitcoinServices"`
+	BitcoinServices map[string]*BitcoinService `json:"bitcoinServices"`
 
 	// SSH
 	SSHKey    string `json:"sshKey"`


### PR DESCRIPTION
This field lives on `AnonymityReport` since fbdf6f202c9956dc53caaeb8c7e7462f09e9acc4.