### PR TITLE
test: Make bitcoin address extraction test less silly

### DIFF
--- a/deanonymization/check_bitcoin_addresses_test.go
+++ b/deanonymization/check_bitcoin_addresses_test.go
@@ -1,8 +1,11 @@
 package deanonymization
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io/ioutil"
+	"strings"
 	"testing"
 )
 
@@ -51,5 +54,9 @@ func TestExtractBitcoinAddress(t *testing.T) {
 
 	if len(ctx.report.BitcoinAddresses) != 100 {
 		t.Error(fmt.Sprintf("Should have detected 100 bitcoin addresses"))
+	}
+	h := sha256.Sum256([]byte(strings.Join(ctx.report.BitcoinAddresses, " ")))
+	if hex.EncodeToString(h[:]) != "aec30c5af50a875042af908cf483170e03c85207d70ffbef7401d1633a69bbdb" {
+		t.Error(fmt.Sprintf("Address misdetection somewhere in testdata/bitcoin.html"))
 	}
 }

--- a/deanonymization/testdata/bitcoin.html
+++ b/deanonymization/testdata/bitcoin.html
@@ -1,15 +1,22 @@
 <html>
+    <head>
+        <meta charset="UTF-8">
+    </head>
     <body>
         <!-- test page for ExtractBitcoinAddress -->
         <p>1HgcMTiRwkCDoJoBowfJv4kTh2NMLo5AxT</p>
         <p>16XDVcDfCFaL1nvHdnduCwbWcS2EHjHTXD</p>
         <p>15TitTkHZDtr7gFvnWeizN2dWPp6jLNQLt</p>
         <p>1Eb4w8QByVkXcfJFNBKA4PQFpD1ayQNoaG</p>
-        <p>1EMgjZLeosT1uBuhL1FAUXAhCGG7X7vXbk</p>
+        <p><a href="bitcoin:1EMgjZLeosT1uBuhL1FAUXAhCGG7X7vXbk?amount=0.00000001&label=12345a">link</a></p>
         <p>13ufxAfM2scx7DLM5hKoSUDScg15YdjDuR</p>
         <p>16GiSio86KN4o1EKSTghxL56Y7e1q9Hw65</p>
         <p>1DkTecvKWUFX8LrBGRCLgKrf7xUdzsCfN5</p>
-        <p>1FsRnbSEppyGdYnfFS7QDhakL56QGgCYQ8</p>
+<style>
+.qr {
+        background-image: url("https://example.onion/showQR/1FsRnbSEppyGdYnfFS7QDhakL56QGgCYQ8");
+}
+</style>
         <p>1KL1tUT9iYMKMMS9ZyeqB7z4eqHiTVrgAz</p>
         <p>17boxahoFsq7h5b2cqWtirojGWXTZ6Ez9P</p>
         <p>1BfpabAwRYhdPDm4yeprUZx1qay9cHJ9XV</p>
@@ -18,13 +25,14 @@
         <p>1BgFykXW5SAbKdaDvmpBs5WWxDfz28UFLE</p>
         <p>14owDDEWKogiyHFpzyY5AFGkgLT5UrfNKA</p>
         <p>1EvBokvSTP13gnmTdiKgQD5AQQuQ9iqS8E</p>
-        <p>13rNsV1XzksvgcMXqeciXCg11jt3kNvuZo</p>
+        <p><a href="bitcoin:13rNsV1XzksvgcMXqeciXCg11jt3kNvuZo?amount=0.00000001&label=12345a">link</a></p>
         <p>1MqqUhQ6a3mYgtGNqFsENDYUTiM66FC28J</p>
         <p>15Crdw2rSTgHDZsNKRVLtHVaPryFEXnJKs</p>
-        <p>1F53HBnBHUvTxYnp7VL7RwbRbX2hv7mhMW</p>
+        <p><img src="https://example.onion/showQR/1F53HBnBHUvTxYnp7VL7RwbRbX2hv7mhMW"/></p>
+        <p><img src="https://example.onion/showQR/%31F53HBnBHUvTxYnp7VL7RwbRbX2hv7mhMW"/></p> <!-- obfuscated: not detected -->
         <p>1JAdPMx6xsbEyTD5xDcZdDRGhTy5Rw7bGy</p>
-        <p>1HJJd3M68aCf14AwExiGbNWSZz1AXZ1FTG</p>
-        <p>1FKFVpyWssXJ7SipZcBudVdgFKaSkh2hGV</p>
+        <p><a href="https://some.blockchain.explorer.onion/1HJJd3M68aCf14AwExiGbNWSZz1AXZ1FTG">link</a></p>
+<!--    <p>1FKFVpyWssXJ7SipZcBudVdgFKaSkh2hGV</p>
         <p>18a5VxRzHMiMHARRxrYq5geEhzKR87oSHL</p>
         <p>1DJkotazqEMYZ58Dj2sjmfasiSt5cQuqgT</p>
         <p>17HcMXdQtYBEXvBsB8ffoBhR7jmpQ7Abn</p>
@@ -41,19 +49,24 @@
         <p>1PupQJKuNTUFG9Lq8BjoVHu39Wbn7cRahH</p>
         <p>1MMCWtCrJ3oxVwejEC1Mi2HqY9VrRJDcPx</p>
         <p>1P5zGfxC739sW9HjoiLeeyeG8ZhjRWExCn</p>
-        <p>1J5emCYori4hskLg9wqhFXwyZaEoHevXt6</p>
-        <p>18owgHeEntUJW5mCX7eWA8mWr1PfCozWRn</p>
+-->
+<!--1J5emCYori4hskLg9wqhFXwyZaEoHevXt6-->
+        <script>var a="18owgHeEntUJW5mCX7eWA8mWr1PfCozWRn";</script>
+        <script>var b="18owgHeEntUJW5mCX"+"7eWA8mWr1PfCozWRn";</script> <!-- obfuscated: not detected -->
         <p>1H13AXY39WMqzr2hryKAHWMkcXdBfhBJ1x</p>
         <p>1Lkk9F73EbzB3JKeKBedmQkQ4Y2LmsRu3</p>
         <p>18FtDcSZKi3LbNUaRkbXGxJjNv1MHk7H11</p>
         <p>12AcWWrMqoUL4b83K1sb4wLyai4Lb8NzK8</p>
         <p>1AaANDT311XrU5z9Q4y17AvB7MnhEwedB2</p>
-        <p>1GyqQLezAnsK67RPZJrPTwfZUfVyfKHZLp</p>
-        <p>1F3HCeL4T9bdwEomiHzxVknEYAbPdLqC33</p>
-        <p>1gxrsjpCmrMaibxHJJ4GDFD4czVw4384m</p>
+        <p>A 1GyqQLezAnsK67RPZJrPTwfZUfVyfKHZLp C</p>
+        <p>1F3H 1F3HCeL4T9bdwEomiHzxVknEYAbPdLqC33 1dLqC33dLqC33dLqC33dLqC33knEYAbPdLqC33</p> <!-- surround with frags that look like addresses -->
+        <p>1gxrsjpCmrM 1gxrsjpCmrMaibxHJJ4GDFD4czVw4384m 1gxrsjpCmrMaibxHJJ4GDFD4czVw4384mgxrsjpCmrMaibxHJJ4GDFD4czVw4384m</p>
         <p>13bAjQ1uXeLgWJXST4yYYz1yWUGRBZBZ2Q</p>
         <p>1FR3TcoQcsv4DYgsT4d4KWNXUUMcEpyz2q</p>
         <p>1851f41CpzSPtA6MdC3W6fehvpXr2Foey2</p>
+        <p>AWBv77f2x2aD2Wts1iHPUPdcx5HJe89NyK</p><!-- valid base58 and checksum and length, but prefix byte 23 so should not be detected -->
+        <p>126d7rV1qFMjBCNryg2z9ege1WFjxVLMYGxo</p><!-- valid base58 and prefix 0 and checksum, but one byte too long before checksum -->
+        <p>126d7rV1qFMjBCNryg2z9ege1WFjxY2nWj4s</p><!-- valid base58 and prefix 0 and checksum, but one byte added after checksum -->
         <p>1JNpMVLiF5oi7pzQpE6kGWWVm4tGYbBNJe</p>
         <p>1HKPF9ubasYkZc3jNgyZw8Rp5gdVRZF9AY</p>
         <p>1HGFwgSqDM541JG6jUQQwomjG8jyzNP4Ls</p>
@@ -66,12 +79,16 @@
         <p>1KrjXoHdJktQdNySUg7Gn1gigj5aHE1fW2</p>
         <p>1LRSFNN8oiQgyMjJWHFVRbXyMBCNpM44ky</p>
         <p>15vMPW47Wmkry3qTQ4DYtV8vM1VjdtoBJd</p>
+        <p>15vMPW47Wmkry3q TQ4DYtV8vM1VjdtoBJd</p><!-- space in between, not currently detected, don't know if it should -->
+        <p>15vMPW47Wmkry3q
+TQ4DYtV8vM1VjdtoBJd</p><!-- newline in between, not currently detected, don't know if it should -->
+        <p>15vMPW47Wmkry3qT﻿Q4DYtV8vM1VjdtoBJd</p><!-- zero-width no-break space in between, not currently detected -->
         <p>17i6JbKDS4hQm39pHouMjJLrBvw9ZF8T2U</p>
         <p>1Dz6R5Du8VzT353DPEWxQhhzDL4ttnvNMT</p>
         <p>1JKnYGRpHxEK4PWMtcB735jTCCdaniCxhk</p>
         <p>15nBtu4FGxmHkDHfYF1pFUT2qYHC8QG43a</p>
         <p>14CV3vxEnT9sNSSDFRKnaZyUi8WRwNw87k</p>
-        <p>1E2yYxpLeoauVFppDj4R5QTsx4NApbnSxs</p>
+        <p>L52r4HGHVKCUAtVxEhwvtSRakbLyDLRzCnWxm41mF2ceoPcd4zdY</p> <!-- private key for 1E2yYxpLeoauVFppDj4R5QTsx4NApbnSxs (see issue #76) -->
         <p>1FHey1ZcTMVuftnxCNfA2opZaiK2Jv7ay6</p>
         <p>1ENjd2yMkVYGtcUtXRmkztYrYmTyrpPLJw</p>
         <p>1CZW3GWF4PgRJFNgnKFGxFexftEBXMkL3q</p>
@@ -86,12 +103,12 @@
         <p>15HeT3Yh7KnbizxXkgFg5utH6axKqLi7uq</p>
         <p>1Jhj78EWVwF6y2ep4B7x8gYxKPcgmHar4g</p>
         <p>1KXK4nGfsfz5EMggqntywZzbNWasR8VpNn</p>
-        <p>1AXR3E15hTEsRYQqHbzoTJfA2Fv5ZzogxQ</p>
-        <p>1Jwd2CDAUGQnw2gkioP9QviH7QeDvhSr1B</p>
-        <p>1FzFMCn5KGYDhdq6ztYWLGwchztjvJbywb</p>
+        <p>░▒▓█1AXR3E15hTEsRYQqHbzoTJfA2Fv5ZzogxQ█▓▒░</p> <!-- unicode -->
+        <p>♬𝄐𝄜𝆒1Jwd2CDAUGQnw2gkioP9QviH7QeDvhSr1B</p>
+        <p>1FzFMCn5KGYDhdq6ztYWLGwchztjvJbywb🎻🎸</p>
         <p>1LRGkKnkkphdBtedwyAzBdKjPFN9ZMZjXH</p>
         <p>1DneFLHXCmTJPYnbj9zpcdJiE34nNH9s5r</p>
-        <p>17W9znZSdSZRi1LHKgh6YnUK898yLQix8W</p>
+        <p>Ì}"tIÎ4Ñ^Ç17W9znZSdSZRi1LHKgh6YnUK898yLQix8WüXÃø¯åJ(þ</p> <!-- /dev/urandom -->
         <p>13pa5JGYrUj57nQNN3QJWSf8pUqKygH8ck</p>
         <p>159kZcHauYvLUCeigrqe8jKm94TB7fJtkA</p>
         <p>1A3EKbzYSDSUwvSgkJR563TrUSx7gB9GXj</p>


### PR DESCRIPTION
Add lots of different contexts, edge cases and tricks (some detected, some not, but all as expected).

Also add a simple step to the test to assure not only 100 addresses have been detected, but also the right ones.

Good news: I was not able to find any bug (e.g. false detection) in the code, even with some of the nastier base58 tricks.