### PR TITLE
Split simple report generation, introduce `-jsonSimpleReport`

### DIFF
--- a/deanonymization/process_report.go
+++ b/deanonymization/process_report.go
@@ -24,5 +24,6 @@ func ProcessReport(osreport *report.OnionScanReport, osc *config.OnionScanConfig
 	utils.RemoveDuplicates(&anonreport.AnalyticsIDs)
 	utils.RemoveDuplicates(&anonreport.BitcoinAddresses)
 	anonreport.OnionScanReport = osreport
+	anonreport.SimpleReport = report.SummarizeToSimpleReport(anonreport)
 	return anonreport
 }

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ func main() {
 
 	torProxyAddress := flag.String("torProxyAddress", "127.0.0.1:9050", "the address of the tor proxy to use")
 	simpleReport := flag.Bool("simpleReport", true, "print out a simple report detailing what is wrong and how to fix it, true by default")
+	jsonSimpleReport := flag.Bool("jsonSimpleReport", false, "print out a simple report as json, false by default")
 	reportFile := flag.String("reportFile", "", "the file destination path for report file - if given, the prefix of the file will be the scanned onion service. If not given, the report will be written to stdout")
 	jsonReport := flag.Bool("jsonReport", false, "print out a json report providing a detailed report of the scan.")
 	verbose := flag.Bool("verbose", false, "print out a verbose log output of the scan")
@@ -42,8 +43,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	if !*simpleReport && !*jsonReport {
-		log.Fatalf("You must set one of --simpleReport or --jsonReport")
+	if !*simpleReport && !*jsonReport && !*jsonSimpleReport {
+		log.Fatalf("You must set one of --simpleReport or --jsonReport or --jsonSimpleReport")
 	}
 
 	onionsToScan := []string{}
@@ -109,8 +110,10 @@ func main() {
 
 		if *jsonReport {
 			report.GenerateJsonReport(file, deanonymization.ProcessReport(scanReport, onionScan.Config))
+		} else if *jsonSimpleReport {
+			report.GenerateSimpleReport(file, deanonymization.ProcessReport(scanReport, onionScan.Config), true)
 		} else if *simpleReport {
-			report.GenerateSimpleReport(file, deanonymization.ProcessReport(scanReport, onionScan.Config))
+			report.GenerateSimpleReport(file, deanonymization.ProcessReport(scanReport, onionScan.Config), false)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/s-rah/onionscan/deanonymization"
 	"github.com/s-rah/onionscan/onionscan"
 	"github.com/s-rah/onionscan/report"
+	"golang.org/x/crypto/ssh/terminal"
 	"io/ioutil"
 	"log"
 	"os"
@@ -111,9 +112,13 @@ func main() {
 		if *jsonReport {
 			report.GenerateJsonReport(file, deanonymization.ProcessReport(scanReport, onionScan.Config))
 		} else if *jsonSimpleReport {
-			report.GenerateSimpleReport(file, deanonymization.ProcessReport(scanReport, onionScan.Config), true)
+			report.GenerateSimpleReport(file, deanonymization.ProcessReport(scanReport, onionScan.Config), true, 0)
 		} else if *simpleReport {
-			report.GenerateSimpleReport(file, deanonymization.ProcessReport(scanReport, onionScan.Config), false)
+			termWidth, _, err := terminal.GetSize(int(os.Stdin.Fd()))
+			if err != nil {
+				termWidth = 80
+			}
+			report.GenerateSimpleReport(file, deanonymization.ProcessReport(scanReport, onionScan.Config), false, termWidth-1)
 		}
 	}
 }

--- a/report/anonymity_report.go
+++ b/report/anonymity_report.go
@@ -32,6 +32,7 @@ type AnonymityReport struct {
 	ExifImages      []ExifImage `json:"exifImages"`
 
 	OnionScanReport *OnionScanReport `json:"onionScanReport"`
+	SimpleReport    *SimpleReport    `json:"simpleReport"`
 }
 
 func (osr *AnonymityReport) AddExifImage(location string) {

--- a/report/report_generator.go
+++ b/report/report_generator.go
@@ -36,118 +36,17 @@ func GenerateJsonReport(reportFile string, report *AnonymityReport) {
 	}
 }
 
-func GenerateSimpleReport(reportFile string, report *AnonymityReport) {
-
-	buffer := bytes.NewBuffer(nil)
-	buffer.WriteString("--------------- OnionScan Report ---------------\n")
-
-	buffer.WriteString(fmt.Sprintf("Generating Report for: %s\n\n", report.OnionScanReport.HiddenService))
-
-	if len(report.EmailAddresses) > 0 {
-		buffer.WriteString("Found Identities:\n")
-		for _, email := range report.EmailAddresses {
-			buffer.WriteString(fmt.Sprintf("\t %s\n", email))
-		}
-		buffer.WriteString("\n")
+func GenerateSimpleReport(reportFile string, report *AnonymityReport, asJSON bool) {
+	var report_str string
+	var err error
+	if asJSON {
+		report_str, err = report.SimpleReport.Serialize()
+	} else {
+		report_str, err = report.SimpleReport.Format()
 	}
-
-	if len(report.IPAddresses) > 0 {
-		buffer.WriteString("Found IP Addresses:\n")
-		for _, ip := range report.IPAddresses {
-			buffer.WriteString(fmt.Sprintf("\t %s\n", ip))
-		}
-		buffer.WriteString("\n")
-	}
-
-	if len(report.RelatedClearnetDomains) > 0 {
-		buffer.WriteString("Found Co-hosted Clearnet Domains:\n")
-		for _, domain := range report.RelatedClearnetDomains {
-			buffer.WriteString(fmt.Sprintf("\t %s\n", domain))
-		}
-		buffer.WriteString("\n")
-	}
-
-	if len(report.RelatedOnionServices) > 0 {
-		buffer.WriteString("Found Co-hosted Onion Domains:\n")
-		for _, domain := range report.RelatedOnionServices {
-			buffer.WriteString(fmt.Sprintf("\t %s\n", domain))
-		}
-		buffer.WriteString("\n")
-	}
-
-	if len(report.AnalyticsIDs) > 0 {
-		buffer.WriteString("Found Analytics IDs:\n")
-		for _, id := range report.AnalyticsIDs {
-			buffer.WriteString(fmt.Sprintf("\t %s\n", id))
-		}
-		buffer.WriteString("\n")
-	}
-
-	if len(report.BitcoinAddresses) > 0 {
-		buffer.WriteString("Found Bitcoin Addresses:\n")
-		for _, id := range report.BitcoinAddresses {
-			buffer.WriteString(fmt.Sprintf("\t %s\n", id))
-		}
-		buffer.WriteString("\n")
-	}
-
-	if report.FoundApacheModStatus {
-		buffer.WriteString("\033[091mHigh Risk:\033[0m Apache mod_status is enabled and accessible\n")
-		buffer.WriteString("\t Why this is bad: An attacker can gain very valuable information\n\t from this internal status page including IP addresses, co-hosted services and user activity.\n")
-		buffer.WriteString("\t To fix, disable mod_status or serve it on a different port than the configured hidden service\n\n")
-	}
-
-	if len(report.RelatedClearnetDomains) > 0 {
-
-		buffer.WriteString("\033[091mHigh Risk:\033[0m You are hosting a clearnet site on the same server as this onion service!\n")
-		buffer.WriteString("\t Why this is bad: This may be intentional, but often isn't.\n\t Services are best operated in isolation such that a compromise of one does not mean a compromise of the other.\n")
-		buffer.WriteString("\t To fix, host all services on separate infrastructure\n\n")
-	}
-
-	if len(report.RelatedOnionServices) > 0 {
-		buffer.WriteString("\033[091mMedium Risk:\033[0m You are hosting multiple onion services on the same server as this onion service!\n")
-		buffer.WriteString("\t Why this is bad: This may be intentional, but often isn't.\n\t Hidden services are best operated in isolation such that a compromise of one does not mean a compromise of the other.\n")
-		buffer.WriteString("\t To fix, host all services on separate infrastructure\n\n")
-	}
-
-	if len(report.OpenDirectories) > 0 {
-		if len(report.OpenDirectories) > 10 {
-			buffer.WriteString("\033[091mMedium Risk:\033[0m Large number of open directories were discovered!\n")
-		} else {
-			buffer.WriteString("\033[091mLow Risk:\033[0m Small number of open directories were discovered!\n")
-		}
-
-		buffer.WriteString("\t Why this is bad: Open directories can reveal the existence of files\n\t not linked from the sites source code. Most of the time this is benign, but sometimes operators forget to clean up more sensitive folders.\n")
-		buffer.WriteString("\t To fix, use .htaccess rules or equivalent to make reading directories listings forbidden.\n")
-		buffer.WriteString("\t Quick Fix (Disable indexing globally) for Debian / Ubuntu running Apache: a2dismod autoindex as root.\n")
-		buffer.WriteString("\t Directories Identified:\n")
-		for _, dir := range report.OpenDirectories {
-			buffer.WriteString(fmt.Sprintf("\t\t%s\n", dir))
-		}
-		buffer.WriteString("\n")
-	}
-
-	if len(report.ExifImages) > 0 {
-		if len(report.ExifImages) > 10 {
-			buffer.WriteString("\033[091mHigh Risk:\033[0m Large number of images with EXIF metadata were discovered!\n")
-		} else {
-			buffer.WriteString("\033[091mMedium Risk:\033[0m Small number of images with EXIF metadata were discovered!\n")
-		}
-
-		buffer.WriteString("\t Why this is bad: EXIF metadata can itself deanonymize a user or\n\t service operator (e.g. GPS location, Name etc.). Or, when combined, can be used to link anonymous identities together.\n")
-		buffer.WriteString("\t To fix, re-encode all images to strip EXIF and other metadata.\n")
-		buffer.WriteString("\t Images Identified:\n")
-		for _, image := range report.ExifImages {
-			buffer.WriteString(fmt.Sprintf("\t\t%s\n", image.Location))
-		}
-		buffer.WriteString("\n")
-	}
-
-	if report.PrivateKeyDetected {
-		buffer.WriteString("\033[091mCritical Risk:\033[0m Hidden service private key is accessible!\n")
-		buffer.WriteString("\t Why this is bad: This can be used to impersonate the service at any point in the future.\n")
-		buffer.WriteString("\t To fix, generate a new hidden service and make sure the private_key file is not reachable from\n")
-		buffer.WriteString("\t the web root\n")
+	if err != nil {
+		log.Printf("Could not generate report")
+		return
 	}
 
 	if len(reportFile) > 0 {
@@ -161,8 +60,8 @@ func GenerateSimpleReport(reportFile string, report *AnonymityReport) {
 
 		defer f.Close()
 
-		f.WriteString(buffer.String())
+		f.WriteString(report_str)
 	} else {
-		fmt.Print(buffer.String())
+		fmt.Print(report_str)
 	}
 }

--- a/report/report_generator.go
+++ b/report/report_generator.go
@@ -36,13 +36,13 @@ func GenerateJsonReport(reportFile string, report *AnonymityReport) {
 	}
 }
 
-func GenerateSimpleReport(reportFile string, report *AnonymityReport, asJSON bool) {
+func GenerateSimpleReport(reportFile string, report *AnonymityReport, asJSON bool, width int) {
 	var report_str string
 	var err error
 	if asJSON {
 		report_str, err = report.SimpleReport.Serialize()
 	} else {
-		report_str, err = report.SimpleReport.Format()
+		report_str, err = report.SimpleReport.Format(width)
 	}
 	if err != nil {
 		log.Printf("Could not generate report")

--- a/report/simple_report.go
+++ b/report/simple_report.go
@@ -73,6 +73,9 @@ func (osr *SimpleReport) Format(width int) (string, error) {
 		buffer.WriteString("\n")
 
 	}
+	if len(osr.Risks) == 0 {
+		buffer.WriteString("No risks were found.\n")
+	}
 	return buffer.String(), nil
 }
 

--- a/report/simple_report.go
+++ b/report/simple_report.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 )
 
+const SEV_INFO = "info"
 const SEV_LOW = "low"
 const SEV_MEDIUM = "medium"
 const SEV_HIGH = "high"
@@ -39,7 +40,8 @@ func (osr *SimpleReport) Serialize() (string, error) {
 }
 
 var risk_levels = map[string]string{
-	SEV_LOW:      "\033[094mLow Risk:\033[0m",
+	SEV_INFO:     "\033[094mInfo:\033[0m",
+	SEV_LOW:      "\033[093mLow Risk:\033[0m",
 	SEV_MEDIUM:   "\033[093mMedium Risk:\033[0m",
 	SEV_HIGH:     "\033[091mHigh Risk:\033[0m",
 	SEV_CRITICAL: "\033[091mCritical Risk:\033[0m",
@@ -81,19 +83,19 @@ func SummarizeToSimpleReport(report *AnonymityReport) *SimpleReport {
 	var out = NewSimpleReport(report.OnionScanReport.HiddenService)
 
 	if len(report.EmailAddresses) > 0 {
-		out.AddRisk(SEV_LOW, "Found Identities", "", "", report.EmailAddresses)
+		out.AddRisk(SEV_INFO, "Found Identities", "", "", report.EmailAddresses)
 	}
 
 	if len(report.IPAddresses) > 0 {
-		out.AddRisk(SEV_LOW, "Found IP Addresses", "", "", report.IPAddresses)
+		out.AddRisk(SEV_INFO, "Found IP Addresses", "", "", report.IPAddresses)
 	}
 
 	if len(report.AnalyticsIDs) > 0 {
-		out.AddRisk(SEV_LOW, "Found Analytics IDs", "", "", report.AnalyticsIDs)
+		out.AddRisk(SEV_INFO, "Found Analytics IDs", "", "", report.AnalyticsIDs)
 	}
 
 	if len(report.BitcoinAddresses) > 0 {
-		out.AddRisk(SEV_LOW, "Found Bitcoin Addresses", "", "", report.BitcoinAddresses)
+		out.AddRisk(SEV_INFO, "Found Bitcoin Addresses", "", "", report.BitcoinAddresses)
 	}
 
 	if report.FoundApacheModStatus {

--- a/report/simple_report.go
+++ b/report/simple_report.go
@@ -1,0 +1,174 @@
+package report
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const SEV_LOW = "low"
+const SEV_MEDIUM = "medium"
+const SEV_HIGH = "high"
+const SEV_CRITICAL = "critical"
+
+type Risk struct {
+	Severity    string   `json:"severity"`
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	Fix         string   `json:"fix"`
+	Items       []string `json:"items"`
+}
+
+type SimpleReport struct {
+	HiddenService string `json:"hiddenService"`
+	Risks         []Risk `json:"risks"`
+}
+
+func (osr *SimpleReport) AddRisk(severity string, title string, description string, fix string, items []string) {
+	osr.Risks = append(osr.Risks, Risk{severity, title, description, fix, items})
+}
+
+// Format as JSON
+func (osr *SimpleReport) Serialize() (string, error) {
+	report, err := json.Marshal(osr)
+	if err != nil {
+		return "", err
+	}
+	return string(report), nil
+}
+
+var risk_levels = map[string]string{
+	SEV_LOW:      "\033[094mLow Risk:\033[0m",
+	SEV_MEDIUM:   "\033[093mMedium Risk:\033[0m",
+	SEV_HIGH:     "\033[091mHigh Risk:\033[0m",
+	SEV_CRITICAL: "\033[091mCritical Risk:\033[0m",
+}
+
+// Format as human-readable text to be printed to console
+func (osr *SimpleReport) Format() (string, error) {
+	buffer := bytes.NewBuffer(nil)
+	buffer.WriteString("--------------- OnionScan Report ---------------\n")
+
+	buffer.WriteString(fmt.Sprintf("Generating Report for: %s\n\n", osr.HiddenService))
+
+	for _, risk := range osr.Risks {
+		buffer.WriteString(risk_levels[risk.Severity] + " " + risk.Title + "\n")
+		if len(risk.Description) > 0 {
+			for _, item := range strings.Split(risk.Description, "\n") {
+				buffer.WriteString("\t " + item + "\n")
+			}
+		}
+		if len(risk.Fix) > 0 {
+			for _, item := range strings.Split(risk.Fix, "\n") {
+				buffer.WriteString("\t " + item + "\n")
+			}
+		}
+		if len(risk.Items) > 0 {
+			buffer.WriteString("\t Items Identified:\n")
+			buffer.WriteString("\n")
+			for _, item := range risk.Items {
+				buffer.WriteString(fmt.Sprintf("\t %s\n", item))
+			}
+		}
+		buffer.WriteString("\n")
+
+	}
+	return buffer.String(), nil
+}
+
+func SummarizeToSimpleReport(report *AnonymityReport) *SimpleReport {
+	var out = NewSimpleReport(report.OnionScanReport.HiddenService)
+
+	if len(report.EmailAddresses) > 0 {
+		out.AddRisk(SEV_LOW, "Found Identities", "", "", report.EmailAddresses)
+	}
+
+	if len(report.IPAddresses) > 0 {
+		out.AddRisk(SEV_LOW, "Found IP Addresses", "", "", report.IPAddresses)
+	}
+
+	if len(report.AnalyticsIDs) > 0 {
+		out.AddRisk(SEV_LOW, "Found Analytics IDs", "", "", report.AnalyticsIDs)
+	}
+
+	if len(report.BitcoinAddresses) > 0 {
+		out.AddRisk(SEV_LOW, "Found Bitcoin Addresses", "", "", report.BitcoinAddresses)
+	}
+
+	if report.FoundApacheModStatus {
+		out.AddRisk(SEV_HIGH, "Apache mod_status is enabled and accessible",
+			"Why this is bad: An attacker can gain very valuable information\n"+
+				"from this internal status page including IP addresses, co-hosted services and user activity.",
+			"To fix, disable mod_status or serve it on a different port than the configured hidden service", nil)
+	}
+
+	if len(report.RelatedClearnetDomains) > 0 {
+		out.AddRisk(SEV_HIGH, "You are hosting a clearnet site on the same server as this onion service!",
+			"Why this is bad: This may be intentional, but often isn't.\n"+
+				"Services are best operated in isolation such that a compromise of one does not mean a compromise of the other.",
+			"To fix, host all services on separate infrastructure", report.RelatedClearnetDomains)
+	}
+
+	if len(report.RelatedOnionServices) > 0 {
+		out.AddRisk(SEV_MEDIUM, "You are hosting multiple onion services on the same server as this onion service!",
+			"Why this is bad: This may be intentional, but often isn't.\n"+
+				"Hidden services are best operated in isolation such that a compromise of one does not mean a compromise of the other.",
+			"To fix, host all services on separate infrastructure", report.RelatedOnionServices)
+	}
+
+	if len(report.OpenDirectories) > 0 {
+		var severity string
+		var title string
+		if len(report.OpenDirectories) > 10 {
+			severity = SEV_MEDIUM
+			title = "Large number of open directories were discovered!"
+		} else {
+			severity = SEV_LOW
+			title = "Small number of open directories were discovered!"
+		}
+
+		out.AddRisk(severity, title,
+			"Why this is bad: Open directories can reveal the existence of files\n"+
+				"not linked from the sites source code. Most of the time this is benign, but sometimes operators forget to clean up more sensitive folders.",
+			"To fix, use .htaccess rules or equivalent to make reading directories listings forbidden.\n"+
+				"Quick Fix (Disable indexing globally) for Debian / Ubuntu running Apache: a2dismod autoindex as root.",
+			report.OpenDirectories)
+	}
+
+	if len(report.ExifImages) > 0 {
+		var severity string
+		var title string
+		if len(report.OpenDirectories) > 10 {
+			severity = SEV_HIGH
+			title = "Large number of images with EXIF metadata were discovered!"
+		} else {
+			severity = SEV_MEDIUM
+			title = "Small number of images with EXIF metadata were discovered!"
+		}
+		items := []string{}
+		for _, image := range report.ExifImages {
+			items = append(items, image.Location)
+		}
+		out.AddRisk(severity, title,
+			"Why this is bad: EXIF metadata can itself deanonymize a user or\n"+
+				"service operator (e.g. GPS location, Name etc.). Or, when combined, can be used to link anonymous identities together.",
+			"To fix, re-encode all images to strip EXIF and other metadata.",
+			items)
+	}
+
+	if report.PrivateKeyDetected {
+		out.AddRisk(SEV_CRITICAL, "Hidden service private key is accessible!",
+			"Why this is bad: This can be used to impersonate the service at any point in the future.",
+			"To fix, generate a new hidden service and make sure the private_key file is not reachable from\n"+
+				"the web root",
+			nil)
+	}
+	return out
+}
+
+func NewSimpleReport(hiddenService string) *SimpleReport {
+	var osr = new(SimpleReport)
+	osr.HiddenService = hiddenService
+	return osr
+}

--- a/utils/format_paragraphs.go
+++ b/utils/format_paragraphs.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"bytes"
+	"strings"
+)
+
+func FormatParagraphs(in string, width int, indent int) string {
+	out := bytes.NewBuffer(nil)
+
+	for il, para := range strings.Split(in, "\n") {
+		rem_width := width
+		if il == 0 { // Assume first line is indented by same amount by caller, subtract from available
+			rem_width -= indent
+		} else {
+			out.WriteString("\n")
+		}
+		for iw, word := range strings.Split(para, " ") {
+			if iw == 0 { // First word of a line - just place it
+				out.WriteString(word)
+				rem_width -= len(word)
+			} else if (len(word) + 1) <= rem_width { // Second or latter - place for space and word
+				out.WriteString(" " + word)
+				rem_width -= len(word) + 1
+			} else { // No place for this word on current line, skip to next line and place it
+				out.WriteString("\n")
+				rem_width = width
+				for i := 0; i < indent; i++ {
+					out.WriteString(" ")
+					rem_width -= 1
+				}
+				out.WriteString(word)
+				rem_width -= len(word)
+			}
+		}
+	}
+	return out.String()
+}

--- a/utils/format_paragraphs_test.go
+++ b/utils/format_paragraphs_test.go
@@ -1,0 +1,45 @@
+package utils
+
+import (
+	"fmt"
+	"testing"
+)
+
+type FormatParagraphsTest struct {
+	input  string
+	width  int
+	indent int
+	output string
+}
+
+var formatParagraphsTests = []FormatParagraphsTest{
+	{"", 79, 0, ""},
+	{"test", 79, 0, "test"},
+	{" test", 79, 0, " test"},
+	{"test test", 79, 0, "test test"},
+	{"test test", 4, 0, "test\ntest"},
+	{"testerde test", 4, 0, "testerde\ntest"},
+	{"test test", 4, 4, "test\n    test"},
+	// Make sure we don't indent a fully-new line following a too-long line ending
+	{"test test\nabc", 4, 4, "test\n    test\nabc"},
+	{"This_is_a_very_long_test_string_without_any_spaces_so_it_should_just_get_returned_as_is_despite_the_length until it gets here", 79, 0, "This_is_a_very_long_test_string_without_any_spaces_so_it_should_just_get_returned_as_is_despite_the_length\nuntil it gets here"},
+	// Test wrap length is exact
+	{"a b c d e f g h i j k l m n o p q r s t u v w x y z 1 2 3 4 5 6 7 8 9 a b c de f g h i j k l m n o p", 79, 0, "a b c d e f g h i j k l m n o p q r s t u v w x y z 1 2 3 4 5 6 7 8 9 a b c de\nf g h i j k l m n o p"},
+	{"x\na b c d e f g h i j k l m n o p q r s t u v w x y z 1 2 3 4 5 6 7 8 9 a b c de f g h i j k l m n o p", 79, 0, "x\na b c d e f g h i j k l m n o p q r s t u v w x y z 1 2 3 4 5 6 7 8 9 a b c de\nf g h i j k l m n o p"},
+	// Indent should be included in length of lines
+	{"x\na b c d e f g h i j k l m n o p q r s t u v w x y z 1 2 3 4 5 6 7 8 9 a b c de f g h i j k l m n o p q r s t u v w x y z 0 1 2 3 4 5 6 7 8 9 a b c d e fg h i j k", 79, 4, "x\na b c d e f g h i j k l m n o p q r s t u v w x y z 1 2 3 4 5 6 7 8 9 a b c de\n    f g h i j k l m n o p q r s t u v w x y z 0 1 2 3 4 5 6 7 8 9 a b c d e fg\n    h i j k"},
+	{"This is a very long test string. This is a second sentence in the very long test string.", 79, 0, "This is a very long test string. This is a second sentence in the very long\ntest string."},
+	{"This is a very long test string.\nThis is a second sentence in the very long test string. This is a third sentence in the very long test string.", 79, 0, "This is a very long test string.\nThis is a second sentence in the very long test string. This is a third\nsentence in the very long test string."},
+	{"This is a very long test string.\n\nThis is a second sentence in the very long test string. This is a third sentence in the very long test string.", 79, 0, "This is a very long test string.\n\nThis is a second sentence in the very long test string. This is a third\nsentence in the very long test string."},
+	{"Testing that normal newlines do not get indented.\nLike here.", 79, 0, "Testing that normal newlines do not get indented.\nLike here."},
+}
+
+func TestFormatParagraphs(t *testing.T) {
+	for _, rec := range formatParagraphsTests {
+		output := FormatParagraphs(rec.input, rec.width, rec.indent)
+		if output != rec.output {
+			t.Error(fmt.Sprintf("Format of \"%s\" (%d,%d) is \"%s\" instead of expected \"%s\"",
+				rec.input, rec.width, rec.indent, output, rec.output))
+		}
+	}
+}


### PR DESCRIPTION
Split generation of simple report into two passes.

- Pass one generates a SimpleReport structure from AnonymityReport
- Pass two generates either JSON or text to console

Add command-line option `-jsonSimpleReport` to specify generation of a JSON simple report.

`-jsonReport` output will also contain the `simpleReport` as one of the fields (I think this was the intention in #35).

Example output:
```json
{
    "hiddenService": "4hwyik7xxwb6pbvb.onion",
    "risks": [
        {
            "severity": "low",
            "title": "Found IP Addresses",
            "description": "",
            "fix": "",
            "items": [
                "1.4.3.2"
            ]
        },
        {
            "severity": "high",
            "title": "Apache mod_status is enabled and accessible",
            "description": "Why this is bad: An attacker can gain very valuable information\nfrom this internal status page including IP addresses, co-hosted services and user activity.",
            "fix": "To fix, disable mod_status or serve it on a different port than the configured hidden service",
            "items": null
        },
        {
            "severity": "medium",
            "title": "Small number of images with EXIF metadata were discovered!",
            "description": "Why this is bad: EXIF metadata can itself deanonymize a user or\nservice operator (e.g. GPS location, Name etc.). Or, when combined, can be used to link anonymous identities together.",
            "fix": "To fix, re-encode all images to strip EXIF and other metadata.",
            "items": [
                "/sample1.jpg"
            ]
        },
        {
            "severity": "critical",
            "title": "Hidden service private key is accessible!",
            "description": "Why this is bad: This can be used to impersonate the service at any point in the future.",
            "fix": "To fix, generate a new hidden service and make sure the private_key file is not reachable from\nthe web root",
            "items": null
        }
    ]
```

Text output remains approximately the same:
```
--------------- OnionScan Report ---------------
Generating Report for: 4hwyik7xxwb6pbvb.onion

Low Risk: Found IP Addresses
         Items Identified:

         1.4.3.2

High Risk: Apache mod_status is enabled and accessible
         Why this is bad: An attacker can gain very valuable information
         from this internal status page including IP addresses, co-hosted services and user activity.
         To fix, disable mod_status or serve it on a different port than the configured hidden service

Medium Risk: Small number of images with EXIF metadata were discovered!
         Why this is bad: EXIF metadata can itself deanonymize a user or
         service operator (e.g. GPS location, Name etc.). Or, when combined, can be used to link anonymous identities together.
         To fix, re-encode all images to strip EXIF and other metadata.
         Items Identified:

         /sample1.jpg

Critical Risk: Hidden service private key is accessible!
         Why this is bad: This can be used to impersonate the service at any point in the future.
         To fix, generate a new hidden service and make sure the private_key file is not reachable from
         the web root
```