### PR TITLE
Check Tor proxy status at startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/s-rah/onionscan/deanonymization"
 	"github.com/s-rah/onionscan/onionscan"
 	"github.com/s-rah/onionscan/report"
+	"github.com/s-rah/onionscan/utils"
 	"golang.org/x/crypto/ssh/terminal"
 	"io/ioutil"
 	"log"
@@ -46,6 +47,11 @@ func main() {
 
 	if !*simpleReport && !*jsonReport && !*jsonSimpleReport {
 		log.Fatalf("You must set one of --simpleReport or --jsonReport or --jsonSimpleReport")
+	}
+
+	proxyStatus := utils.CheckTorProxy(*torProxyAddress)
+	if proxyStatus != utils.ProxyStatusOK {
+		log.Fatalf("%s, is the --torProxyAddress setting correct?", utils.ProxyStatusMessage(proxyStatus))
 	}
 
 	onionsToScan := []string{}

--- a/utils/proxycheck.go
+++ b/utils/proxycheck.go
@@ -1,0 +1,62 @@
+package utils
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type ProxyStatus int
+
+const (
+	ProxyStatusOK ProxyStatus = iota
+	ProxyStatusWrongType
+	ProxyStatusCannotConnect
+	ProxyStatusTimeout
+)
+
+// Detect whether a proxy is connectable and is a Tor proxy
+func CheckTorProxy(proxyAddress string) ProxyStatus {
+	// A trick to do this without making an outward connection is,
+	// paradoxically, to try to open it as http.
+	// This is documented in section 4 here: https://github.com/torproject/torspec/blob/master/socks-extensions.txt
+	client := &http.Client{Timeout: 2 * time.Second}
+	response, err := client.Get("http://" + proxyAddress + "/")
+	if err != nil {
+		switch t := err.(type) {
+		case *url.Error:
+			switch t.Err.(type) {
+			case *net.OpError: // Network-level error. Will in turn contain a os.SyscallError
+				return ProxyStatusCannotConnect
+			default:
+				// http.error unfortunately not exported, need to match on string
+				// net/http: request canceled
+				if strings.Index(t.Err.Error(), "request canceled") != -1 {
+					return ProxyStatusTimeout
+				}
+			}
+		}
+		// Protocol-level errors mean that http failed, so it's not Tor
+		return ProxyStatusWrongType
+	}
+	defer response.Body.Close()
+	if response.Status != "501 Tor is not an HTTP Proxy" {
+		return ProxyStatusWrongType
+	}
+	return ProxyStatusOK
+}
+
+func ProxyStatusMessage(status ProxyStatus) string {
+	switch status {
+	case ProxyStatusWrongType:
+		return "Proxy specified is not a Tor proxy"
+	case ProxyStatusCannotConnect:
+		return "Cannot connect to Tor proxy"
+	case ProxyStatusTimeout:
+		return "Proxy timeout"
+	default:
+		return "Unknown proxy error"
+	}
+}


### PR DESCRIPTION
Detect if the tor proxy is Available and if not log an error on startup (#54).

This checks if the proxy is connectable and actually Tor, without connecting through to anything. If not it gives a targeted error message. It does not have any logic for I2P (#72), but that could be added in a similar way later and possibly have its own command-line argument.