### PR TITLE
Introduce Relationship Database + OnionScan Design

### DIFF
--- a/crawldb/crawldb_test.go
+++ b/crawldb/crawldb_test.go
@@ -28,3 +28,44 @@ func TestCrawlDB(t *testing.T) {
 		t.Errorf("Could not find crawl record in the database!")
 	}
 }
+
+func TestRelationship(t *testing.T) {
+
+	dbdir, err := ioutil.TempDir("", "test-crawl")
+	if err != nil {
+		t.Error(fmt.Sprintf("Error creating temporary directory: %s", err))
+	}
+	defer os.RemoveAll(dbdir)
+
+	db := new(CrawlDB)
+	db.NewDB(dbdir)
+	_, err = db.InsertRelationship("example.onion", "ssh", "12:23:32:DE:AD:BE:EF")
+	if err != nil {
+		t.Errorf("Relationship record was not stored in the database!")
+	}
+
+	_, err = db.InsertRelationship("example2.onion", "ssh", "12:23:32:DE:AD:BE:EF")
+	if err != nil {
+		t.Errorf("Relationship record was not stored in the database!")
+	}
+
+	result, _ := db.GetOnionsWithIdentifier("12:23:32:DE:AD:BE:EF")
+
+	if result == nil {
+		t.Errorf("Could not find relationships in the database!")
+	}
+
+	if len(result) != 2 {
+		t.Errorf("Relationships returned %d results, should return 2", len(result))
+	}
+
+	// DB could return results out of order.
+	if result[0] == "example.onion" && result[1] == "example2.onion" {
+		// OK
+	} else if result[1] == "example.onion" && result[2] == "example2.onion" {
+		// OK
+	} else {
+		t.Errorf("Relationships returned wrong onions %v", result)
+	}
+
+}

--- a/design/000-onionscan.md
+++ b/design/000-onionscan.md
@@ -1,0 +1,53 @@
+# OnionScan - The Dark Web Forensics Toolkit
+
+*Author: Sarah Jamie Lewis*
+*Created: 2016-10-06*
+*Status: Draft*
+*Target: 0.2*
+
+# Overview
+
+   This document describes the goals, scope and direction of the OnionScan tool.
+   
+   
+# Goals
+
+   OnionScan is a free and open source tool for investigating the Dark Web. The
+   audience for OnionScan is large and varied, for the purposes of this document
+   we will divide the types of users into the following categories:
+
+   * People with an intermediate level of knowledge who should be able to use OnionScan
+     to find operational security issues with their site.
+   * Researchers and Investigators who should be able to use OnionScan to 
+     monitor and track Dark Web sites.
+
+   These two distinct groups need different but related functionality and we should
+   aim to serve both groups.
+   
+   Regardless of the expansion of the OnionScan tool it should always been possible
+   for a naive user point OnionScan at a site and get immediate, useful results.
+   
+# In Scope
+
+   OnionScan is primarily interested in automating the following functions:
+
+   * Identifying misconfigurations in hidden services that may lead to deanonymization.
+   * Identifying operational security violations that may lead to deanonymization.
+   * Identifying correlations between multiple hidden services.
+   * Providing a platform for further analysis of hidden services e.g classification.
+   * Provide a way to store and track changes to services over time.
+   
+   In addition to the above, OnionScan should also act as a generic and 
+   configurable crawler:
+   
+   * Discovering and following links to new services
+   * Intelligently crawling sites for certain content e.g. users and listings 
+     on marketplaces
+   * Providing snapshots of pages now and in the past.
+ 
+# Not In Scope
+
+   OnionScan is not a general vulnerability scanner or security tool. We should
+   not introduce features and scans that can be commonly found in other tools
+   targetted at regular websites e.g. XSS detection.
+

--- a/design/001-database.md
+++ b/design/001-database.md
@@ -1,0 +1,56 @@
+# OnionScan Database Proposal
+
+*Author: Sarah Jamie Lewis*
+*Created: 2016-10-06*
+*Status: Draft*
+*Target: 0.2*
+
+## Overview
+
+   This document describes the requirements and design for the 
+   internal OnionScan database.
+   
+### Raw Crawl Data
+
+   * Web Page Snapshots
+   * Image Snapshots
+   * Raw Protocol Info e.g. SSH Key, Fingerprint and Software Banner
+   * Crawl Metadata e.g. Date/Time and Length
+   
+   Keyed against the fully qualified URL of the determined protocol e.g.
+   `http://example.onion/index.php` or `ssh://example.com:29`
+   
+   All of these URLs are tied to the scan report.
+
+### Identifier Nodes
+
+   * Identifiers derived form raw crawl data e.g. Bitcoin Addresses, 
+     IP Addresses etc.
+     
+   Stored as a triple: `onion hostname`, `type of identifier`, `identifier string` 
+   e.g. `example.onion`, `bitcoin_address`, `1CFCJHzSAC12VaJt2s1BwXgpb6beo9yWZU`
+
+   The user should be able to search any of the derived identifiers.
+ 
+### Correlation Search
+   
+   * Finding services that share the same SSH key fingerprint.
+   * Finding services that list the same Bitcoin Address.
+     
+    Using the Identifier Nodes, indexed by `identifier string`, we can efficiently
+    search for onions that share the same identifiers.
+     
+### General Search
+
+   * Ad-hoc search requires in response to user data e.g. "find all the sites
+     that contain the word 'drug'"
+     
+   This is the trickiest one to implement. At the moment the only way to do this
+   would be to perform a full-scan search across the whole raw crawl data. In the
+   future we may want to optimize this - but as it stands, this inefficiency seems
+   like a good trade off with the rest of the database design.
+     
+   
+
+   
+   


### PR DESCRIPTION
This commit introduces the concept of storing identifier
relationships in a seperate store from the raw crawl data.

This will make it easy to built the Analytics Framework and
identify correlations.

The future of the database structure is now partially defined
in the design/ folder, where new major design changes should
be documented.

In the design folder is also a draft for an overall OnionScan vision
that I have been kicking around in my head.