### PR TITLE
Add documentation on crawl-configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,17 @@
 
 [![Build Status](https://travis-ci.org/s-rah/onionscan.svg?branch=onionscan-0.2)](https://travis-ci.org/s-rah/onionscan)
 
+## What is OnionScan?
+
+OnionScan is a free and open source tool for investigating the Dark Web.
+
 The purpose of this tool is to make you a better onion service provider. You owe
 it to yourself and your users to ensure that attackers cannot easily exploit and 
 deanonymize.
+
+OnionScan is not a general vulnerability scanner or security tool. It does not
+feature scans that can be commonly found in other tools targetted at regular
+websites e.g. XSS detection.
 
 ## Go Dependencies
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,13 @@ To only scan for the web service and skip the other scans
 
 `./bin/onionscan --scans web --torProxyAddress=127.0.0.1:9150 blahblahblah.onion`
 
-## Apache mod_status Protection
+More detailed documentation on usage can be found in [doc](doc/README.md).
+
+## What is scanned for?
+
+Listed below are a few of the more serious privacy problems that may be found during a scan.
+
+### Apache mod_status Protection
 
 This [should not be news](http://arstechnica.com/security/2016/02/default-settings-in-apache-may-decloak-tor-hidden-services/), you should not have it enabled. If you do have it enabled, attacks can:
 
@@ -62,7 +68,7 @@ This [should not be news](http://arstechnica.com/security/2016/02/default-settin
 Seriously, don't even run the tool, go to your site and check if you have `/server-status`
 reachable. If you do, turn it off!
 
-## Open Directories 
+### Open Directories
 
 Basic web security 101, if you leave directories open then people are going to scan
 them, and find interesting things - old versions of images, temp files etc.
@@ -70,7 +76,7 @@ them, and find interesting things - old versions of images, temp files etc.
 Many sites use common structures `style/`, `images/` etc. The tool checks for
 common variations, and allows the user to submit others for testing. 
 
-## EXIF Tags
+### EXIF Tags
 
 Whether you create them yourself or allow users to upload images, you need to
 ensure the metadata associated with the image is stripped.
@@ -78,7 +84,7 @@ ensure the metadata associated with the image is stripped.
 Many, many websites still do not properly sanitise image data, leaving themselves
 or their users at risk of deanonymization.
 
-## Server Fingerprint
+### Server Fingerprint
 
 Sometimes, even without mod_status we can determine if two sites are hosted on
  the same infrastructure. We can use the following attributes to make this distinction:

--- a/README.md
+++ b/README.md
@@ -51,47 +51,5 @@ More detailed documentation on usage can be found in [doc](doc/README.md).
 
 ## What is scanned for?
 
-Listed below are a few of the more serious privacy problems that may be found during a scan.
-
-### Apache mod_status Protection
-
-This [should not be news](http://arstechnica.com/security/2016/02/default-settings-in-apache-may-decloak-tor-hidden-services/), you should not have it enabled. If you do have it enabled, attacks can:
-
-* Build a better fingerprint of your server, including php and other software versions.
-* Determine client IP addresses if you are co-hosting a clearnet site.
-* Determine your IP address if your setup allows.
-* Determine other sites you are co-hosting.
-* Determine how active your site is.
-* Find secret or hidden areas of your site
-* and much, much more.
-
-Seriously, don't even run the tool, go to your site and check if you have `/server-status`
-reachable. If you do, turn it off!
-
-### Open Directories
-
-Basic web security 101, if you leave directories open then people are going to scan
-them, and find interesting things - old versions of images, temp files etc.
-
-Many sites use common structures `style/`, `images/` etc. The tool checks for
-common variations, and allows the user to submit others for testing. 
-
-### EXIF Tags
-
-Whether you create them yourself or allow users to upload images, you need to
-ensure the metadata associated with the image is stripped.
-
-Many, many websites still do not properly sanitise image data, leaving themselves
-or their users at risk of deanonymization.
-
-### Server Fingerprint
-
-Sometimes, even without mod_status we can determine if two sites are hosted on
- the same infrastructure. We can use the following attributes to make this distinction:
-
-* Server HTTP Header
-* Technology Stack (e.g. php, jquery version etc.)
-* Website folder layout e.g. do you use `/style` or `/css` or do you use wordpress.
-* Fingerprints of images
-* GPG Versions being used.
-
+An list of privacy and security problems which are detected by OnionScan can be
+found [here](doc/what-is-scanned-for.md).

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,3 @@
+## Configuring scans
+
+- [Crawl configuration](crawl-configuration.md)

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,3 +1,7 @@
+## General information
+
+- [What is scanned for?](what-is-scanned-for.md)
+
 ## Configuring scans
 
 - [Crawl configuration](crawl-configuration.md)

--- a/doc/crawl-configuration.md
+++ b/doc/crawl-configuration.md
@@ -1,0 +1,41 @@
+Crawl configuration
+====================
+
+Providing crawl configuration
+------------------------------
+
+The directory from which crawl configurations are fetched from is specified
+using the command-line option `-crawlconfigdir <path>`.
+
+In this directory there should be a file per hidden service that needs specific
+configuration options. For example `ab23cd45ef67gh76.onion.json`; though the name of the file
+is not parsed so any naming convention can be used.
+
+Configuring the scan for a service does not automatically cause it to be
+scanned. They still need to be specified explicitly, either on the command
+line or in a `-list` file.
+
+Configuration structure
+------------------------
+
+    {
+	"onion": "aabbccddeeffgghh.onion",
+	"base": "/forums",
+	"exclude": [
+	    "/profile",
+	    "/settings"
+	]
+    }
+
+The following configuration parameters can currently be specified:
+
+- `onion`: The hostname of the service to configure scanning for. This should
+  be just the hostname, and have no `http://` prefix or path components.
+
+- `base`: configures the base path, relative to the root of the site (to ignore
+  all other parts of a site and focus on a specific set of URLs e.g. `/forums`)
+
+- `exclude`: tells the scanner to ignore URLs which contain one or more of the
+  given strings - this allows explicitly ignoring uninteresting URLs (e.g.
+  `/profile` or `/settings`) and also for avoiding URLs which might mess up the
+  scan (e.g. `/logout`)

--- a/doc/what-is-scanned-for.md
+++ b/doc/what-is-scanned-for.md
@@ -1,0 +1,50 @@
+# What is scanned for?
+
+Listed below are a few of the more serious privacy problems that may be found
+during a scan, ordered per scan type.
+
+## Web sites
+
+When OnionScan detects a web server, it is scanned for the issues described in this section.
+
+### Apache mod_status Protection
+
+This [should not be news](http://arstechnica.com/security/2016/02/default-settings-in-apache-may-decloak-tor-hidden-services/), you should not have it enabled. If you do have it enabled, attacks can:
+
+* Build a better fingerprint of your server, including php and other software versions.
+* Determine client IP addresses if you are co-hosting a clearnet site.
+* Determine your IP address if your setup allows.
+* Determine other sites you are co-hosting.
+* Determine how active your site is.
+* Find secret or hidden areas of your site
+* and much, much more.
+
+Seriously, don't even run the tool, go to your site and check if you have `/server-status`
+reachable. If you do, turn it off!
+
+### Open Directories
+
+Basic web security 101, if you leave directories open then people are going to scan
+them, and find interesting things - old versions of images, temp files etc.
+
+Many sites use common structures `style/`, `images/` etc. The tool checks for
+common variations, and allows the user to submit others for testing. 
+
+### EXIF Tags
+
+Whether you create them yourself or allow users to upload images, you need to
+ensure the metadata associated with the image is stripped.
+
+Many, many websites still do not properly sanitise image data, leaving themselves
+or their users at risk of deanonymization.
+
+### Server Fingerprint
+
+Sometimes, even without mod_status we can determine if two sites are hosted on
+ the same infrastructure. We can use the following attributes to make this distinction:
+
+* Server HTTP Header
+* Technology Stack (e.g. php, jquery version etc.)
+* Website folder layout e.g. do you use `/style` or `/css` or do you use wordpress.
+* Fingerprints of images
+* GPG Versions being used.


### PR DESCRIPTION
- Tried to document the new crawl configuration in `crawl-configuration.md`.
- Added a new directory for detailed documentation (`doc`) where documents about advanced functionality such as  e.g. mass scanning can be placed, and added references to this.
- Moved the suggestion sections in README.md under a parent section "What is scanned for?".

Please let me know if I'm on the right track with this.