### PR TITLE
Updated gitignore to ignore onionscan binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ Desktop.ini
 # OS X
 .DS_Store
 .Trashes
+
+# Binaries
+/onionscan


### PR DESCRIPTION
Simple change that ignores binary so that git doesn't track it by mistake.