### PR TITLE
Look for cyptocurrency (Bitcoin) private keys

### DIFF
--- a/deanonymization/check_bitcoin_addresses.go
+++ b/deanonymization/check_bitcoin_addresses.go
@@ -10,57 +10,56 @@ import (
 	"strings"
 )
 
-// A25 is a type for a 25 byte (not base58 encoded) bitcoin address.
-type A25 [25]byte
-
-// Version extracts the version byte from a bitcoin address
-func (a *A25) Version() byte {
-	return a[0]
-}
-
-// EmbeddedChecksum returns the checksum of a bitcoin address
-func (a *A25) EmbeddedChecksum() (c [4]byte) {
-	copy(c[:], a[21:])
-	return
-}
-
-// DoubleSHA256 computes a double sha256 hash of the first 21 bytes of the
-// address.  This is the one function shared with the other bitcoin RC task.
-// Returned is the full 32 byte sha256 hash.  (The bitcoin checksum will be
-// the first four bytes of the slice.)
-func (a *A25) doubleSHA256() []byte {
-	h := sha256.New()
-	h.Write(a[:21])
-	d := h.Sum([]byte{})
-	h = sha256.New()
-	h.Write(d)
-	return h.Sum(d[:0])
-}
-
-// ComputeChecksum returns a four byte checksum computed from the first 21
-// bytes of the address.  The embedded checksum is not updated.
-func (a *A25) ComputeChecksum() (c [4]byte) {
-	copy(c[:], a.doubleSHA256())
-	return
-}
-
 // Tmpl and Set58 are adapted from the C solution.
 // Go has big integers but this techinique seems better.
 var tmpl = []byte("123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz")
 
-// Set58 takes a base58 encoded address and decodes it into the receiver.
-// Errors are returned if the argument is not valid base58 or if the decoded
-// value does not fit in the 25 byte address.  The address is not otherwise
-// checked for validity.
-func (a *A25) Set58(s []byte) error {
+// ValidateA58 validates a base58 encoded bitcoin address.  An address is valid
+// if it can be decoded into a 25 byte address, the version number is 0
+// (P2PKH) or 5 (P2SH), and the checksum validates.  Return value ok will be
+// true for valid addresses.  If ok is false, the address is invalid and the
+// error value may indicate why.
+func ValidateA58(a58 []byte) (ok bool) {
+	a := make([]byte, 25)
+	if err := Set58(a58, a); err != nil {
+		return false
+	}
+	if Version(a) != 0 && Version(a) != 5 {
+		return false
+	}
+	return EmbeddedChecksum(a) == ComputeChecksum(a)
+}
+
+// ValidateP58 validates a base58 encoded private key.  A private key is valid
+// if it can be decoded into a 37 byte private key, start with a 0x80 byte,
+// and the checksum validates.  Return value ok will be true for valid private keys.
+// If ok is false, the private key is invalid and the error value may indicate why.
+func ValidateP58(p58 []byte) (ok bool) {
+	p := make([]byte, 37)
+	if p58[0] != 'L' && p58[0] != 'K' {
+		return false
+	}
+	if err := Set58(p58[1:], p); err != nil {
+		return false
+	}
+	if Version(p) != 128 {
+		return false
+	}
+	return EmbeddedChecksum(p) == ComputeChecksum(p)
+}
+
+// Set58 takes a base58 encoded string decodes it into a byte slice.
+// Errors are returned if the argument is not a valid base58 or if the decoded
+// value does not fit in the byte slice.
+func Set58(s []byte, b []byte) error {
 	for _, s1 := range s {
 		c := bytes.IndexByte(tmpl, s1)
 		if c < 0 {
 			return errors.New("bad char")
 		}
-		for j := 24; j >= 0; j-- {
-			c += 58 * int(a[j])
-			a[j] = byte(c % 256)
+		for j := len(b) - 1; j >= 0; j-- {
+			c += 58 * int(b[j])
+			b[j] = byte(c % 256)
 			c /= 256
 		}
 		if c > 0 {
@@ -70,33 +69,56 @@ func (a *A25) Set58(s []byte) error {
 	return nil
 }
 
-// ValidA58 validates a base58 encoded bitcoin address.  An address is valid
-// if it can be decoded into a 25 byte address, the version number is 0
-// (P2PKH) or 5 (P2SH), and the checksum validates.  Return value ok will be
-// true for valid addresses.  If ok is false, the address is invalid and the
-// error value may indicate why.
-func ValidA58(a58 []byte) (ok bool) {
-	var a A25
-	if err := a.Set58(a58); err != nil {
-		return false
-	}
-	if a.Version() != 0 && a.Version() != 5 {
-		return false
-	}
-	return a.EmbeddedChecksum() == a.ComputeChecksum()
+// Version extracts the version byte from the byte slice.
+func Version(b []byte) byte {
+	return b[0]
+}
+
+// ComputeChecksum returns a four byte checksum computed from bytes (except for
+// the last 4) of the slice.  The embedded checksum is not updated.
+func ComputeChecksum(b []byte) (c [4]byte) {
+	copy(c[:], doubleSHA256(b))
+	return
+}
+
+// EmbeddedChecksum returns the checksum of the byte slice.
+func EmbeddedChecksum(b []byte) (c [4]byte) {
+	copy(c[:], b[len(b)-4:])
+	return
+}
+
+// DoubleSHA256 computes a double sha256 hash of bytes (except for the last 4)
+// of the slice.  This is the one function shared with the other bitcoin RC task.
+// Returned is the full 32 byte sha256 hash.  (The checksum will be the first
+// four bytes of the slice.)
+func doubleSHA256(b []byte) []byte {
+	h := sha256.New()
+	h.Write(b[:len(b)-4])
+	d := h.Sum([]byte{})
+	h = sha256.New()
+	h.Write(d)
+	return h.Sum(d[:0])
 }
 
 // ExtractBitcoinAddress extracts any information related to bitcoin addresses from the current crawl.
 func ExtractBitcoinAddress(osreport *report.OnionScanReport, anonreport *report.AnonymityReport, osc *config.OnionScanConfig) {
 	bcaregex := regexp.MustCompile(`[13][a-km-zA-HJ-NP-Z1-9]{25,34}`)
+	pkregex := regexp.MustCompile(`[LK][a-km-zA-HJ-NP-Z1-9]{51}`)
 	for _, id := range osreport.Crawls {
 		crawlRecord, _ := osc.Database.GetCrawlRecord(id)
 		if strings.Contains(crawlRecord.Page.Headers.Get("Content-Type"), "text/html") {
 			foundBCID := bcaregex.FindAllString(crawlRecord.Page.Snapshot, -1)
 			for _, result := range foundBCID {
-				if ValidA58([]byte(result)) {
+				if ValidateA58([]byte(result)) {
 					anonreport.BitcoinAddresses = append(anonreport.BitcoinAddresses, result)
 					osc.Database.InsertRelationship(osreport.HiddenService, "snapshot", "bitcoin-address", result)
+				}
+			}
+			foundPKID := pkregex.FindAllString(crawlRecord.Page.Snapshot, -1)
+			for _, result := range foundPKID {
+				if ValidateP58([]byte(result)) {
+					anonreport.BitcoinPrivateKeys = append(anonreport.BitcoinPrivateKeys, result)
+					osc.Database.InsertRelationship(osreport.HiddenService, "snapshot", "bitcoin-private-key", result)
 				}
 			}
 		}

--- a/deanonymization/check_bitcoin_addresses_test.go
+++ b/deanonymization/check_bitcoin_addresses_test.go
@@ -42,7 +42,18 @@ func TestExtractBitcoinAddress(t *testing.T) {
 		t.Errorf("Unexpected bitcoin address found")
 	}
 
-	// Test 4: Multiple addresses
+	// Test 4: WIF bitcoin private key
+	ctx.CreatePage("/index.html", 200, "text/html", "<html><body>L5Kb8kLf9zgWQnogidDA76MzPL6TsZZY36hWXMssSzNydYXYB9KF</body></html>")
+	ExtractBitcoinAddress(ctx.osreport, ctx.report, ctx.osc)
+
+	if len(ctx.report.BitcoinPrivateKeys) != 1 {
+		t.Errorf("Should have detected a bitcoin private key")
+	}
+	if ctx.report.BitcoinPrivateKeys[0] != "L5Kb8kLf9zgWQnogidDA76MzPL6TsZZY36hWXMssSzNydYXYB9KF" {
+		t.Errorf("Unexpected bitcoin private key found")
+	}
+
+	// Test 5: Multiple addresses
 	ctx.report.BitcoinAddresses = []string{}
 	data, err := ioutil.ReadFile("testdata/bitcoin.html")
 	if err != nil {

--- a/report/anonymity_report.go
+++ b/report/anonymity_report.go
@@ -27,6 +27,7 @@ type AnonymityReport struct {
 	EmailAddresses         []string `json:"emailAddresses"`
 	AnalyticsIDs           []string `json:"analyticsIDs"`
 	BitcoinAddresses       []string `json:"bitcoinAddresses"`
+	BitcoinPrivateKeys     []string `json:"bitcoinPrivateKeys"`
 	LinkedOnions           []string `json:"linkedOnions"`
 
 	OpenDirectories []string    `json:"openDirectories"`

--- a/report/simple_report.go
+++ b/report/simple_report.go
@@ -118,7 +118,15 @@ func (srt *BitcoinAddressesCheck) Check(out *SimpleReport, report *AnonymityRepo
 	if len(report.BitcoinAddresses) > 0 {
 		out.AddRisk(SEV_INFO, "Found Bitcoin Addresses", "", "", report.BitcoinAddresses)
 	}
+}
 
+// BitcoinPrivateKeysCheck implementation
+type BitcoinPrivateKeysCheck struct{}
+
+func (srt *BitcoinPrivateKeysCheck) Check(out *SimpleReport, report *AnonymityReport) {
+	if len(report.BitcoinPrivateKeys) > 0 {
+		out.AddRisk(SEV_CRITICAL, "Found Bitcoin Addresses", "", "", report.BitcoinPrivateKeys)
+	}
 }
 
 // ApacheModStatusCheck implementation

--- a/webui/webui.go
+++ b/webui/webui.go
@@ -381,6 +381,8 @@ func (wui *WebUI) Index(w http.ResponseWriter, r *http.Request) {
 				alt = "PGP Identities"
 			case "bitcoin-address":
 				alt = "Bitcoin Addresses"
+			case "bitcoin-private-key":
+				alt = "Bitcoin Private Keys"
 			case "software-banner":
 				alt = "Software Banners"
 			case "analytics-id":


### PR DESCRIPTION
I have started my attempt at addressing #76 (looking for cryptocurrency private keys). This is my first GoLang PR for an OS project and I welcome any feedback and assistance.

There is a few things I'm unsure of in my approach:
- Should I be creating a new type and functions for handling private keys (37 bytes vs 25 bytes for addresses)
- My implementation is based on the format described [here](https://en.bitcoin.it/wiki/Private_key#Base58_Wallet_Import_format) but in [bitcoin.html on line 91](https://github.com/s-rah/onionscan/blob/45b2de5424db2f590838ccdb9ad2cc34d97c29fc/deanonymization/testdata/bitcoin.html#L91) the private key begins with an 'L'. When using [this private key validator](http://gobittest.appspot.com/PrivateKey), it it unable to validate this private key. Even when I remove the 'L' character, it does not pass the checksum tests.
