### PR TITLE
Dispatch onion scans from table

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func main() {
 	if *scans != "" {
 		scanslist = strings.Split(*scans, ",")
 	} else {
-		scanslist = onionScan.GetAllActions()
+		scanslist = onionScan.GetAllActions(true)
 	}
 
 	onionScan.Config = config.Configure(*torProxyAddress, *directoryDepth, *fingerprint, *timeout, *dbdir, scanslist, *crawlconfigdir, *cookiestring, *verbose)


### PR DESCRIPTION
Create a single table `allScans` with a mapping from scan name to `{protocol.Scanner,bool runByDefault}`. Remove the function `PerformNextAction` with the huge switch statement and instead directly use the map for dispatching. Also use this map in `GetAllActions` to avoid duplication.

The only user visible impact should be that the scans are re-ordered.

This is just an experiment, don't know if you'll see it as an improvement :)